### PR TITLE
[Doc] Update accuracy reports for main

### DIFF
--- a/accuracy/accuracy_report/Qwen2.5-7B-Instruct-V0.md
+++ b/accuracy/accuracy_report/Qwen2.5-7B-Instruct-V0.md
@@ -1,0 +1,94 @@
+# 🎯 Qwen2.5-7B-Instruct Accuracy Test
+  <div>
+    <strong>vLLM version:</strong> vLLM: 0.1.dev1, vLLM Ascend: main <br>
+  </div>
+  <div>
+      <strong>Software Environment:</strong> CANN: 8.1.RC1, PyTorch: 2.5.1, torch-npu: 2.5.1 <br>
+  </div>
+  <div>
+      <strong>Hardware Environment</strong>: Atlas A2 Series <br>
+  </div>
+  <div>
+      <strong>Datasets</strong>: ceval-valid,gsm8k <br>
+  </div>
+  <div>
+      <strong>Command</strong>: 
+
+  ```bash
+  export MODEL_ARGS='pretrained=Qwen/Qwen2.5-7B-Instruct, max_model_len=4096,dtype=auto,tensor_parallel_size=2,gpu_memory_utilization=0.6'
+lm_eval --model vllm --modlel_args $MODEL_ARGS --tasks ceval-valid,gsm8k \ 
+--apply_chat_template --fewshot_as_multiturn --num_fewshot 5 --batch_size 1
+  ```
+  </div>
+  <div>&nbsp;</div>
+  
+| Task                  | Filter | n-shot | Metric   | Value   | Stderr |
+|-----------------------|-------:|-------:|----------|--------:|-------:|
+| ceval-valid                           | none   | 5      | acc_norm | ↑ 0.8001 | ± 0.0105 |
+| gsm8k                                 | flexible-extract | 5      | exact_match | ↑ 0.7278 | ± 0.0123 |
+<details>
+<summary>ceval-valid details</summary>
+
+| Task                  | Filter | n-shot | Metric   | Value   | Stderr |
+|-----------------------|-------:|-------:|----------|--------:|-------:|
+| ceval-valid                           | none   | 5      | acc_norm | ↑ 0.8001 | ± 0.0105 |
+| - ceval-valid_accountant              | none   | 5      | acc    | ↑ 0.8776 | ± 0.0473 |
+| - ceval-valid_advanced_mathematics    | none   | 5      | acc    | ↑ 0.4211 | ± 0.1164 |
+| - ceval-valid_art_studies             | none   | 5      | acc    | ↑ 0.7273 | ± 0.0787 |
+| - ceval-valid_basic_medicine          | none   | 5      | acc    | ↑ 0.9474 | ± 0.0526 |
+| - ceval-valid_business_administration | none   | 5      | acc    | ↑ 0.8485 | ± 0.0634 |
+| - ceval-valid_chinese_language_and_literature | none   | 5      | acc    | ↑ 0.6087 | ± 0.1041 |
+| - ceval-valid_civil_servant           | none   | 5      | acc    | ↑ 0.8298 | ± 0.0554 |
+| - ceval-valid_clinical_medicine       | none   | 5      | acc    | ↑ 0.7727 | ± 0.0914 |
+| - ceval-valid_college_chemistry       | none   | 5      | acc    | ↑ 0.6250 | ± 0.1009 |
+| - ceval-valid_college_economics       | none   | 5      | acc    | ↑ 0.7455 | ± 0.0593 |
+| - ceval-valid_college_physics         | none   | 5      | acc    | ↑ 0.7368 | ± 0.1038 |
+| - ceval-valid_college_programming     | none   | 5      | acc    | ↑ 0.8649 | ± 0.0570 |
+| - ceval-valid_computer_architecture   | none   | 5      | acc    | ↑ 0.7143 | ± 0.1010 |
+| - ceval-valid_computer_network        | none   | 5      | acc    | ↑ 0.6842 | ± 0.1096 |
+| - ceval-valid_discrete_mathematics    | none   | 5      | acc    | ↑ 0.2500 | ± 0.1118 |
+| - ceval-valid_education_science       | none   | 5      | acc    | ↑ 0.8621 | ± 0.0652 |
+| - ceval-valid_electrical_engineer     | none   | 5      | acc    | ↑ 0.6757 | ± 0.0780 |
+| - ceval-valid_environmental_impact_assessment_engineer | none   | 5      | acc    | ↑ 0.7419 | ± 0.0799 |
+| - ceval-valid_fire_engineer           | none   | 5      | acc    | ↑ 0.7419 | ± 0.0799 |
+| - ceval-valid_high_school_biology     | none   | 5      | acc    | ↑ 0.8947 | ± 0.0723 |
+| - ceval-valid_high_school_chemistry   | none   | 5      | acc    | ↑ 0.7368 | ± 0.1038 |
+| - ceval-valid_high_school_chinese     | none   | 5      | acc    | ↑ 0.6842 | ± 0.1096 |
+| - ceval-valid_high_school_geography   | none   | 5      | acc    | ↑ 0.8947 | ± 0.0723 |
+| - ceval-valid_high_school_history     | none   | 5      | acc    | ↑ 0.9000 | ± 0.0688 |
+| - ceval-valid_high_school_mathematics | none   | 5      | acc    | ↑ 0.5000 | ± 0.1213 |
+| - ceval-valid_high_school_physics     | none   | 5      | acc    | ↑ 0.7368 | ± 0.1038 |
+| - ceval-valid_high_school_politics    | none   | 5      | acc    | ↑ 0.8947 | ± 0.0723 |
+| - ceval-valid_ideological_and_moral_cultivation | none   | 5      | acc    | ↑ 0.9474 | ± 0.0526 |
+| - ceval-valid_law                     | none   | 5      | acc    | ↑ 0.6667 | ± 0.0983 |
+| - ceval-valid_legal_professional      | none   | 5      | acc    | ↑ 0.7391 | ± 0.0936 |
+| - ceval-valid_logic                   | none   | 5      | acc    | ↑ 0.6364 | ± 0.1050 |
+| - ceval-valid_mao_zedong_thought      | none   | 5      | acc    | ↑ 0.9583 | ± 0.0417 |
+| - ceval-valid_marxism                 | none   | 5      | acc    | ↑ 0.9474 | ± 0.0526 |
+| - ceval-valid_metrology_engineer      | none   | 5      | acc    | ↑ 0.8333 | ± 0.0777 |
+| - ceval-valid_middle_school_biology   | none   | 5      | acc    | ↑ 0.9524 | ± 0.0476 |
+| - ceval-valid_middle_school_chemistry | none   | 5      | acc    | ↑ 0.9500 | ± 0.0500 |
+| - ceval-valid_middle_school_geography | none   | 5      | acc    | ↑ 0.9167 | ± 0.0833 |
+| - ceval-valid_middle_school_history   | none   | 5      | acc    | ↑ 0.9091 | ± 0.0627 |
+| - ceval-valid_middle_school_mathematics | none   | 5      | acc    | ↑ 0.6842 | ± 0.1096 |
+| - ceval-valid_middle_school_physics   | none   | 5      | acc    | ↑ 0.9474 | ± 0.0526 |
+| - ceval-valid_middle_school_politics  | none   | 5      | acc    | ↑ 1.0000 | ± 0.0000 |
+| - ceval-valid_modern_chinese_history  | none   | 5      | acc    | ↑ 0.9130 | ± 0.0601 |
+| - ceval-valid_operating_system        | none   | 5      | acc    | ↑ 0.8421 | ± 0.0859 |
+| - ceval-valid_physician               | none   | 5      | acc    | ↑ 0.8367 | ± 0.0533 |
+| - ceval-valid_plant_protection        | none   | 5      | acc    | ↑ 0.8636 | ± 0.0749 |
+| - ceval-valid_probability_and_statistics | none   | 5      | acc    | ↑ 0.5556 | ± 0.1205 |
+| - ceval-valid_professional_tour_guide | none   | 5      | acc    | ↑ 0.8966 | ± 0.0576 |
+| - ceval-valid_sports_science          | none   | 5      | acc    | ↑ 0.9474 | ± 0.0526 |
+| - ceval-valid_tax_accountant          | none   | 5      | acc    | ↑ 0.8571 | ± 0.0505 |
+| - ceval-valid_teacher_qualification   | none   | 5      | acc    | ↑ 0.9091 | ± 0.0438 |
+| - ceval-valid_urban_and_rural_planner | none   | 5      | acc    | ↑ 0.8043 | ± 0.0591 |
+| - ceval-valid_veterinary_medicine     | none   | 5      | acc    | ↑ 0.8261 | ± 0.0808 |
+</details>
+<details>
+<summary>gsm8k details</summary>
+
+| Task                  | Filter | n-shot | Metric   | Value   | Stderr |
+|-----------------------|-------:|-------:|----------|--------:|-------:|
+| gsm8k                                 | flexible-extract | 5      | exact_match | ↑ 0.7278 | ± 0.0123 |
+</details>

--- a/accuracy/accuracy_report/Qwen2.5-7B-Instruct-V1.md
+++ b/accuracy/accuracy_report/Qwen2.5-7B-Instruct-V1.md
@@ -1,4 +1,4 @@
-# 🎯 Qwen3-8B-Base Accuracy Test
+# 🎯 Qwen2.5-7B-Instruct Accuracy Test
   <div>
     <strong>vLLM version:</strong> vLLM: 0.1.dev1, vLLM Ascend: main <br>
   </div>
@@ -15,7 +15,7 @@
       <strong>Command</strong>: 
 
   ```bash
-  export MODEL_ARGS='pretrained=Qwen/Qwen3-8B-Base, max_model_len=4096,dtype=auto,tensor_parallel_size=2,gpu_memory_utilization=0.6'
+  export MODEL_ARGS='pretrained=Qwen/Qwen2.5-7B-Instruct, max_model_len=4096,dtype=auto,tensor_parallel_size=2,gpu_memory_utilization=0.6'
 lm_eval --model vllm --modlel_args $MODEL_ARGS --tasks ceval-valid,gsm8k \ 
 --apply_chat_template --fewshot_as_multiturn --num_fewshot 5 --batch_size 1
   ```
@@ -24,14 +24,14 @@ lm_eval --model vllm --modlel_args $MODEL_ARGS --tasks ceval-valid,gsm8k \
   
 | Task                  | Filter | n-shot | Metric   | Value   | Stderr |
 |-----------------------|-------:|-------:|----------|--------:|-------:|
-| ceval-valid                           | none   | 5      | acc_norm | ↑ 0.2303 | ± 0.0115 |
-| gsm8k                                 | flexible-extract | 5      | exact_match | ↑ 0.8309 | ± 0.0103 |
+| ceval-valid                           | none   | 5      | acc    | ↑ 0.2303 | ± 0.0115 |
+| gsm8k                                 | flexible-extract | 5      | exact_match | ↑ 0.7233 | ± 0.0123 |
 <details>
 <summary>ceval-valid details</summary>
 
 | Task                  | Filter | n-shot | Metric   | Value   | Stderr |
 |-----------------------|-------:|-------:|----------|--------:|-------:|
-| ceval-valid                           | none   | 5      | acc_norm | ↑ 0.2303 | ± 0.0115 |
+| ceval-valid                           | none   | 5      | acc    | ↑ 0.2303 | ± 0.0115 |
 | - ceval-valid_accountant              | none   | 5      | acc    | ↑ 0.2245 | ± 0.0602 |
 | - ceval-valid_advanced_mathematics    | none   | 5      | acc    | ↑ 0.3158 | ± 0.1096 |
 | - ceval-valid_art_studies             | none   | 5      | acc    | ↑ 0.4545 | ± 0.0880 |
@@ -90,5 +90,5 @@ lm_eval --model vllm --modlel_args $MODEL_ARGS --tasks ceval-valid,gsm8k \
 
 | Task                  | Filter | n-shot | Metric   | Value   | Stderr |
 |-----------------------|-------:|-------:|----------|--------:|-------:|
-| gsm8k                                 | flexible-extract | 5      | exact_match | ↑ 0.8309 | ± 0.0103 |
+| gsm8k                                 | flexible-extract | 5      | exact_match | ↑ 0.7233 | ± 0.0123 |
 </details>

--- a/accuracy/accuracy_report/Qwen2.5-VL-7B-Instruct-V0.md
+++ b/accuracy/accuracy_report/Qwen2.5-VL-7B-Instruct-V0.md
@@ -1,0 +1,70 @@
+# 🎯 Qwen2.5-VL-7B-Instruct Accuracy Test
+  <div>
+    <strong>vLLM version:</strong> vLLM: 0.1.dev1, vLLM Ascend: main <br>
+  </div>
+  <div>
+      <strong>Software Environment:</strong> CANN: 8.1.RC1, PyTorch: 2.5.1, torch-npu: 2.5.1 <br>
+  </div>
+  <div>
+      <strong>Hardware Environment</strong>: Atlas A2 Series <br>
+  </div>
+  <div>
+      <strong>Datasets</strong>: mmmu_val <br>
+  </div>
+  <div>
+      <strong>Command</strong>: 
+
+  ```bash
+  export MODEL_ARGS='pretrained=Qwen/Qwen2.5-VL-7B-Instruct, max_model_len=8192,dtype=auto,tensor_parallel_size=4,max_images=2'
+lm_eval --model vllm-vlm --modlel_args $MODEL_ARGS --tasks mmmu_val \ 
+--apply_chat_template --fewshot_as_multiturn  --batch_size 1
+  ```
+  </div>
+  <div>&nbsp;</div>
+  
+| Task                  | Filter | n-shot | Metric   | Value   | Stderr |
+|-----------------------|-------:|-------:|----------|--------:|-------:|
+| mmmu_val                              | none   | 0      | acc    | ↑ 0.5133 | ± 0.0162 |
+<details>
+<summary>mmmu_val details</summary>
+
+| Task                  | Filter | n-shot | Metric   | Value   | Stderr |
+|-----------------------|-------:|-------:|----------|--------:|-------:|
+| mmmu_val                              | none   | 0      | acc    | ↑ 0.5133 | ± 0.0162 |
+| - Art and Design                      | none   | 0      | acc    | ↑ 0.6750 | ± 0.0424 |
+| - Art                                 | none   | 0      | acc    | ↑ 0.6667 | ± 0.0875 |
+| - Art Theory                          | none   | 0      | acc    | ↑ 0.8333 | ± 0.0692 |
+| - Design                              | none   | 0      | acc    | ↑ 0.6667 | ± 0.0875 |
+| - Music                               | none   | 0      | acc    | ↑ 0.5333 | ± 0.0926 |
+| - Business                            | none   | 0      | acc    | ↑ 0.4200 | ± 0.0405 |
+| - Accounting                          | none   | 0      | acc    | ↑ 0.4333 | ± 0.0920 |
+| - Economics                           | none   | 0      | acc    | ↑ 0.5333 | ± 0.0926 |
+| - Finance                             | none   | 0      | acc    | ↑ 0.3333 | ± 0.0875 |
+| - Manage                              | none   | 0      | acc    | ↑ 0.3333 | ± 0.0875 |
+| - Marketing                           | none   | 0      | acc    | ↑ 0.4667 | ± 0.0926 |
+| - Health and Medicine                 | none   | 0      | acc    | ↑ 0.5733 | ± 0.0406 |
+| - Basic Medical Science               | none   | 0      | acc    | ↑ 0.6000 | ± 0.0910 |
+| - Clinical Medicine                   | none   | 0      | acc    | ↑ 0.6000 | ± 0.0910 |
+| - Diagnostics and Laboratory Medicine | none   | 0      | acc    | ↑ 0.4333 | ± 0.0920 |
+| - Pharmacy                            | none   | 0      | acc    | ↑ 0.6000 | ± 0.0910 |
+| - Public Health                       | none   | 0      | acc    | ↑ 0.6333 | ± 0.0895 |
+| - Humanities and Social Science       | none   | 0      | acc    | ↑ 0.6917 | ± 0.0419 |
+| - History                             | none   | 0      | acc    | ↑ 0.7000 | ± 0.0851 |
+| - Literature                          | none   | 0      | acc    | ↑ 0.8000 | ± 0.0743 |
+| - Psychology                          | none   | 0      | acc    | ↑ 0.7333 | ± 0.0821 |
+| - Sociology                           | none   | 0      | acc    | ↑ 0.5333 | ± 0.0926 |
+| - Science                             | none   | 0      | acc    | ↑ 0.4200 | ± 0.0407 |
+| - Biology                             | none   | 0      | acc    | ↑ 0.3667 | ± 0.0895 |
+| - Chemistry                           | none   | 0      | acc    | ↑ 0.3667 | ± 0.0895 |
+| - Geography                           | none   | 0      | acc    | ↑ 0.4667 | ± 0.0926 |
+| - Math                                | none   | 0      | acc    | ↑ 0.5000 | ± 0.0928 |
+| - Physics                             | none   | 0      | acc    | ↑ 0.4000 | ± 0.0910 |
+| - Tech and Engineering                | none   | 0      | acc    | ↑ 0.4095 | ± 0.0341 |
+| - Agriculture                         | none   | 0      | acc    | ↑ 0.5000 | ± 0.0928 |
+| - Architecture and Engineering        | none   | 0      | acc    | ↑ 0.4333 | ± 0.0920 |
+| - Computer Science                    | none   | 0      | acc    | ↑ 0.4000 | ± 0.0910 |
+| - Electronics                         | none   | 0      | acc    | ↑ 0.3333 | ± 0.0875 |
+| - Energy and Power                    | none   | 0      | acc    | ↑ 0.2667 | ± 0.0821 |
+| - Materials                           | none   | 0      | acc    | ↑ 0.4333 | ± 0.0920 |
+| - Mechanical Engineering              | none   | 0      | acc    | ↑ 0.5000 | ± 0.0928 |
+</details>


### PR DESCRIPTION
The accuracy results running on Ascend NPU have changed, updating reports for:
All models (Qwen2.5-7B-Instruct, Qwen2.5-VL-7B-Instruct, Qwen3-8B-Base)

- [Workflow run][1]

[1]: https://github.com/nv-action/vllm-benchmarks/actions/runs/15457308618