### PR TITLE
[Doc] Update accuracy reports for 

### DIFF
--- a/accuracy/accuracy_report/Qwen2.5-VL-7B-Instruct-V1.md
+++ b/accuracy/accuracy_report/Qwen2.5-VL-7B-Instruct-V1.md
@@ -1,0 +1,61 @@
+# Qwen2.5-VL-7B-Instruct
+**vLLM Version**: vLLM: 0.9.2 ([a5dd03c](https://github.com/vllm-project/vllm/commit/a5dd03c)), vLLM Ascend: main ([643e6f5](https://github.com/vllm-project/vllm-ascend/commit/643e6f5))  
+**Software Environment**: CANN: 8.1.RC1, PyTorch: 2.5.1, torch-npu: 2.5.1.post1.dev20250619  
+**Hardware Environment**: Atlas A2 Series  
+**Datasets**: mmmu_val  
+**vLLM Engine**: V1  
+**Parallel Mode**: TP  
+**Execution Mode**: ACLGraph  
+**Command**:  
+```bash
+export MODEL_ARGS='pretrained=Qwen/Qwen2.5-VL-7B-Instruct,max_model_len=8192,dtype=auto,tensor_parallel_size=2,max_images=2'
+lm_eval --model vllm-vlm --model_args $MODEL_ARGS --tasks mmmu_val \ 
+--apply_chat_template --fewshot_as_multiturn  --batch_size 1
+```
+  
+| Task                  | Filter | n-shot | Metric   | Value   | Stderr |
+|-----------------------|-------:|-------:|----------|--------:|-------:|
+| mmmu_val                              | none   | 0      | acc    | ✅0.5222 | ± 0.0162 |
+<details>
+<summary>mmmu_val details</summary>
+
+| Task                  | Filter | n-shot | Metric   | Value   | Stderr |
+|-----------------------|-------:|-------:|----------|--------:|-------:|
+| mmmu_val                              | none   | 0      | acc    | ✅0.5222 | ± 0.0162 |
+| - Art and Design                      | none   | 0      | acc    | 0.6667 | ± 0.0424 |
+| - Art                                 | none   | 0      | acc    | 0.6667 | ± 0.0875 |
+| - Art Theory                          | none   | 0      | acc    | 0.8333 | ± 0.0692 |
+| - Design                              | none   | 0      | acc    | 0.6667 | ± 0.0875 |
+| - Music                               | none   | 0      | acc    | 0.5000 | ± 0.0928 |
+| - Business                            | none   | 0      | acc    | 0.4267 | ± 0.0406 |
+| - Accounting                          | none   | 0      | acc    | 0.4333 | ± 0.0920 |
+| - Economics                           | none   | 0      | acc    | 0.5333 | ± 0.0926 |
+| - Finance                             | none   | 0      | acc    | 0.3667 | ± 0.0895 |
+| - Manage                              | none   | 0      | acc    | 0.3333 | ± 0.0875 |
+| - Marketing                           | none   | 0      | acc    | 0.4667 | ± 0.0926 |
+| - Health and Medicine                 | none   | 0      | acc    | 0.6067 | ± 0.0401 |
+| - Basic Medical Science               | none   | 0      | acc    | 0.6000 | ± 0.0910 |
+| - Clinical Medicine                   | none   | 0      | acc    | 0.6667 | ± 0.0875 |
+| - Diagnostics and Laboratory Medicine | none   | 0      | acc    | 0.4667 | ± 0.0926 |
+| - Pharmacy                            | none   | 0      | acc    | 0.6667 | ± 0.0875 |
+| - Public Health                       | none   | 0      | acc    | 0.6333 | ± 0.0895 |
+| - Humanities and Social Science       | none   | 0      | acc    | 0.7000 | ± 0.0413 |
+| - History                             | none   | 0      | acc    | 0.7000 | ± 0.0851 |
+| - Literature                          | none   | 0      | acc    | 0.8333 | ± 0.0692 |
+| - Psychology                          | none   | 0      | acc    | 0.7333 | ± 0.0821 |
+| - Sociology                           | none   | 0      | acc    | 0.5333 | ± 0.0926 |
+| - Science                             | none   | 0      | acc    | 0.4267 | ± 0.0409 |
+| - Biology                             | none   | 0      | acc    | 0.4000 | ± 0.0910 |
+| - Chemistry                           | none   | 0      | acc    | 0.3667 | ± 0.0895 |
+| - Geography                           | none   | 0      | acc    | 0.5000 | ± 0.0928 |
+| - Math                                | none   | 0      | acc    | 0.4333 | ± 0.0920 |
+| - Physics                             | none   | 0      | acc    | 0.4333 | ± 0.0920 |
+| - Tech and Engineering                | none   | 0      | acc    | 0.4143 | ± 0.0341 |
+| - Agriculture                         | none   | 0      | acc    | 0.5333 | ± 0.0926 |
+| - Architecture and Engineering        | none   | 0      | acc    | 0.4333 | ± 0.0920 |
+| - Computer Science                    | none   | 0      | acc    | 0.4333 | ± 0.0920 |
+| - Electronics                         | none   | 0      | acc    | 0.3333 | ± 0.0875 |
+| - Energy and Power                    | none   | 0      | acc    | 0.2667 | ± 0.0821 |
+| - Materials                           | none   | 0      | acc    | 0.4333 | ± 0.0920 |
+| - Mechanical Engineering              | none   | 0      | acc    | 0.4667 | ± 0.0926 |
+</details>

--- a/accuracy/accuracy_report/Qwen3-30B-A3B-V1.md
+++ b/accuracy/accuracy_report/Qwen3-30B-A3B-V1.md
@@ -1,0 +1,85 @@
+# Qwen3-30B-A3B
+**vLLM Version**: vLLM: 0.9.2 ([a5dd03c](https://github.com/vllm-project/vllm/commit/a5dd03c)), vLLM Ascend: main ([643e6f5](https://github.com/vllm-project/vllm-ascend/commit/643e6f5))  
+**Software Environment**: CANN: 8.1.RC1, PyTorch: 2.5.1, torch-npu: 2.5.1.post1.dev20250619  
+**Hardware Environment**: Atlas A2 Series  
+**Datasets**: ceval-valid,gsm8k  
+**vLLM Engine**: V1  
+**Parallel Mode**: EP  
+**Execution Mode**: ACLGraph  
+**Command**:  
+```bash
+export MODEL_ARGS='pretrained=Qwen/Qwen3-30B-A3B,max_model_len=4096,dtype=auto,tensor_parallel_size=4,gpu_memory_utilization=0.6,enable_expert_parallel=True'
+lm_eval --model vllm --model_args $MODEL_ARGS --tasks ceval-valid,gsm8k \ 
+--apply_chat_template --fewshot_as_multiturn --num_fewshot 5 --batch_size 1
+```
+  
+| Task                  | Filter | n-shot | Metric   | Value   | Stderr |
+|-----------------------|-------:|-------:|----------|--------:|-------:|
+| ceval-valid                           | none   | 5      | acc_norm | ✅0.8366 | ± 0.0100 |
+| gsm8k                                 | flexible-extract | 5      | exact_match | ✅0.8469 | ± 0.0099 |
+<details>
+<summary>ceval-valid details</summary>
+
+| Task                  | Filter | n-shot | Metric   | Value   | Stderr |
+|-----------------------|-------:|-------:|----------|--------:|-------:|
+| ceval-valid                           | none   | 5      | acc_norm | ✅0.8366 | ± 0.0100 |
+| - ceval-valid_accountant              | none   | 5      | acc    | 0.8571 | ± 0.0505 |
+| - ceval-valid_advanced_mathematics    | none   | 5      | acc    | 0.6316 | ± 0.1137 |
+| - ceval-valid_art_studies             | none   | 5      | acc    | 0.7879 | ± 0.0723 |
+| - ceval-valid_basic_medicine          | none   | 5      | acc    | 0.7895 | ± 0.0961 |
+| - ceval-valid_business_administration | none   | 5      | acc    | 0.7879 | ± 0.0723 |
+| - ceval-valid_chinese_language_and_literature | none   | 5      | acc    | 0.7826 | ± 0.0879 |
+| - ceval-valid_civil_servant           | none   | 5      | acc    | 0.8085 | ± 0.0580 |
+| - ceval-valid_clinical_medicine       | none   | 5      | acc    | 0.8182 | ± 0.0842 |
+| - ceval-valid_college_chemistry       | none   | 5      | acc    | 0.7083 | ± 0.0948 |
+| - ceval-valid_college_economics       | none   | 5      | acc    | 0.7818 | ± 0.0562 |
+| - ceval-valid_college_physics         | none   | 5      | acc    | 0.8421 | ± 0.0859 |
+| - ceval-valid_college_programming     | none   | 5      | acc    | 0.9459 | ± 0.0377 |
+| - ceval-valid_computer_architecture   | none   | 5      | acc    | 0.9048 | ± 0.0656 |
+| - ceval-valid_computer_network        | none   | 5      | acc    | 0.6842 | ± 0.1096 |
+| - ceval-valid_discrete_mathematics    | none   | 5      | acc    | 0.5625 | ± 0.1281 |
+| - ceval-valid_education_science       | none   | 5      | acc    | 0.9310 | ± 0.0479 |
+| - ceval-valid_electrical_engineer     | none   | 5      | acc    | 0.7027 | ± 0.0762 |
+| - ceval-valid_environmental_impact_assessment_engineer | none   | 5      | acc    | 0.7742 | ± 0.0763 |
+| - ceval-valid_fire_engineer           | none   | 5      | acc    | 0.8710 | ± 0.0612 |
+| - ceval-valid_high_school_biology     | none   | 5      | acc    | 0.9474 | ± 0.0526 |
+| - ceval-valid_high_school_chemistry   | none   | 5      | acc    | 0.8947 | ± 0.0723 |
+| - ceval-valid_high_school_chinese     | none   | 5      | acc    | 0.7368 | ± 0.1038 |
+| - ceval-valid_high_school_geography   | none   | 5      | acc    | 0.9474 | ± 0.0526 |
+| - ceval-valid_high_school_history     | none   | 5      | acc    | 0.9000 | ± 0.0688 |
+| - ceval-valid_high_school_mathematics | none   | 5      | acc    | 0.6667 | ± 0.1143 |
+| - ceval-valid_high_school_physics     | none   | 5      | acc    | 0.8947 | ± 0.0723 |
+| - ceval-valid_high_school_politics    | none   | 5      | acc    | 1.0000 | ± 0.0000 |
+| - ceval-valid_ideological_and_moral_cultivation | none   | 5      | acc    | 0.8947 | ± 0.0723 |
+| - ceval-valid_law                     | none   | 5      | acc    | 0.7917 | ± 0.0847 |
+| - ceval-valid_legal_professional      | none   | 5      | acc    | 0.7826 | ± 0.0879 |
+| - ceval-valid_logic                   | none   | 5      | acc    | 0.7727 | ± 0.0914 |
+| - ceval-valid_mao_zedong_thought      | none   | 5      | acc    | 0.9167 | ± 0.0576 |
+| - ceval-valid_marxism                 | none   | 5      | acc    | 0.9474 | ± 0.0526 |
+| - ceval-valid_metrology_engineer      | none   | 5      | acc    | 0.8750 | ± 0.0690 |
+| - ceval-valid_middle_school_biology   | none   | 5      | acc    | 0.9048 | ± 0.0656 |
+| - ceval-valid_middle_school_chemistry | none   | 5      | acc    | 1.0000 | ± 0.0000 |
+| - ceval-valid_middle_school_geography | none   | 5      | acc    | 0.9167 | ± 0.0833 |
+| - ceval-valid_middle_school_history   | none   | 5      | acc    | 0.9545 | ± 0.0455 |
+| - ceval-valid_middle_school_mathematics | none   | 5      | acc    | 1.0000 | ± 0.0000 |
+| - ceval-valid_middle_school_physics   | none   | 5      | acc    | 0.9474 | ± 0.0526 |
+| - ceval-valid_middle_school_politics  | none   | 5      | acc    | 0.9524 | ± 0.0476 |
+| - ceval-valid_modern_chinese_history  | none   | 5      | acc    | 0.8696 | ± 0.0718 |
+| - ceval-valid_operating_system        | none   | 5      | acc    | 0.6842 | ± 0.1096 |
+| - ceval-valid_physician               | none   | 5      | acc    | 0.8367 | ± 0.0533 |
+| - ceval-valid_plant_protection        | none   | 5      | acc    | 0.8636 | ± 0.0749 |
+| - ceval-valid_probability_and_statistics | none   | 5      | acc    | 0.7778 | ± 0.1008 |
+| - ceval-valid_professional_tour_guide | none   | 5      | acc    | 0.8966 | ± 0.0576 |
+| - ceval-valid_sports_science          | none   | 5      | acc    | 0.8421 | ± 0.0859 |
+| - ceval-valid_tax_accountant          | none   | 5      | acc    | 0.7755 | ± 0.0602 |
+| - ceval-valid_teacher_qualification   | none   | 5      | acc    | 0.9545 | ± 0.0318 |
+| - ceval-valid_urban_and_rural_planner | none   | 5      | acc    | 0.7391 | ± 0.0655 |
+| - ceval-valid_veterinary_medicine     | none   | 5      | acc    | 0.8261 | ± 0.0808 |
+</details>
+<details>
+<summary>gsm8k details</summary>
+
+| Task                  | Filter | n-shot | Metric   | Value   | Stderr |
+|-----------------------|-------:|-------:|----------|--------:|-------:|
+| gsm8k                                 | flexible-extract | 5      | exact_match | ✅0.8469 | ± 0.0099 |
+</details>

--- a/accuracy/accuracy_report/Qwen3-8B-Base-V1.md
+++ b/accuracy/accuracy_report/Qwen3-8B-Base-V1.md
@@ -1,0 +1,85 @@
+# Qwen3-8B-Base
+**vLLM Version**: vLLM: 0.9.2 ([a5dd03c](https://github.com/vllm-project/vllm/commit/a5dd03c)), vLLM Ascend: main ([643e6f5](https://github.com/vllm-project/vllm-ascend/commit/643e6f5))  
+**Software Environment**: CANN: 8.1.RC1, PyTorch: 2.5.1, torch-npu: 2.5.1.post1.dev20250619  
+**Hardware Environment**: Atlas A2 Series  
+**Datasets**: ceval-valid,gsm8k  
+**vLLM Engine**: V1  
+**Parallel Mode**: TP  
+**Execution Mode**: ACLGraph  
+**Command**:  
+```bash
+export MODEL_ARGS='pretrained=Qwen/Qwen3-8B-Base,max_model_len=4096,dtype=auto,tensor_parallel_size=2,gpu_memory_utilization=0.6'
+lm_eval --model vllm --model_args $MODEL_ARGS --tasks ceval-valid,gsm8k \ 
+--apply_chat_template --fewshot_as_multiturn --num_fewshot 5 --batch_size 1
+```
+  
+| Task                  | Filter | n-shot | Metric   | Value   | Stderr |
+|-----------------------|-------:|-------:|----------|--------:|-------:|
+| ceval-valid                           | none   | 5      | acc_norm | ✅0.8187 | ± 0.0102 |
+| gsm8k                                 | flexible-extract | 5      | exact_match | ✅0.8400 | ± 0.0101 |
+<details>
+<summary>ceval-valid details</summary>
+
+| Task                  | Filter | n-shot | Metric   | Value   | Stderr |
+|-----------------------|-------:|-------:|----------|--------:|-------:|
+| ceval-valid                           | none   | 5      | acc_norm | ✅0.8187 | ± 0.0102 |
+| - ceval-valid_accountant              | none   | 5      | acc    | 0.8367 | ± 0.0533 |
+| - ceval-valid_advanced_mathematics    | none   | 5      | acc    | 0.6316 | ± 0.1137 |
+| - ceval-valid_art_studies             | none   | 5      | acc    | 0.8182 | ± 0.0682 |
+| - ceval-valid_basic_medicine          | none   | 5      | acc    | 0.8947 | ± 0.0723 |
+| - ceval-valid_business_administration | none   | 5      | acc    | 0.8485 | ± 0.0634 |
+| - ceval-valid_chinese_language_and_literature | none   | 5      | acc    | 0.6522 | ± 0.1015 |
+| - ceval-valid_civil_servant           | none   | 5      | acc    | 0.7660 | ± 0.0624 |
+| - ceval-valid_clinical_medicine       | none   | 5      | acc    | 0.8636 | ± 0.0749 |
+| - ceval-valid_college_chemistry       | none   | 5      | acc    | 0.7083 | ± 0.0948 |
+| - ceval-valid_college_economics       | none   | 5      | acc    | 0.7273 | ± 0.0606 |
+| - ceval-valid_college_physics         | none   | 5      | acc    | 0.8421 | ± 0.0859 |
+| - ceval-valid_college_programming     | none   | 5      | acc    | 0.8649 | ± 0.0570 |
+| - ceval-valid_computer_architecture   | none   | 5      | acc    | 0.8095 | ± 0.0878 |
+| - ceval-valid_computer_network        | none   | 5      | acc    | 0.7368 | ± 0.1038 |
+| - ceval-valid_discrete_mathematics    | none   | 5      | acc    | 0.3750 | ± 0.1250 |
+| - ceval-valid_education_science       | none   | 5      | acc    | 0.9310 | ± 0.0479 |
+| - ceval-valid_electrical_engineer     | none   | 5      | acc    | 0.6216 | ± 0.0808 |
+| - ceval-valid_environmental_impact_assessment_engineer | none   | 5      | acc    | 0.7742 | ± 0.0763 |
+| - ceval-valid_fire_engineer           | none   | 5      | acc    | 0.7419 | ± 0.0799 |
+| - ceval-valid_high_school_biology     | none   | 5      | acc    | 0.8947 | ± 0.0723 |
+| - ceval-valid_high_school_chemistry   | none   | 5      | acc    | 0.8421 | ± 0.0859 |
+| - ceval-valid_high_school_chinese     | none   | 5      | acc    | 0.6316 | ± 0.1137 |
+| - ceval-valid_high_school_geography   | none   | 5      | acc    | 0.9474 | ± 0.0526 |
+| - ceval-valid_high_school_history     | none   | 5      | acc    | 0.9000 | ± 0.0688 |
+| - ceval-valid_high_school_mathematics | none   | 5      | acc    | 0.6111 | ± 0.1182 |
+| - ceval-valid_high_school_physics     | none   | 5      | acc    | 0.9474 | ± 0.0526 |
+| - ceval-valid_high_school_politics    | none   | 5      | acc    | 0.8947 | ± 0.0723 |
+| - ceval-valid_ideological_and_moral_cultivation | none   | 5      | acc    | 1.0000 | ± 0.0000 |
+| - ceval-valid_law                     | none   | 5      | acc    | 0.6667 | ± 0.0983 |
+| - ceval-valid_legal_professional      | none   | 5      | acc    | 0.8261 | ± 0.0808 |
+| - ceval-valid_logic                   | none   | 5      | acc    | 0.7727 | ± 0.0914 |
+| - ceval-valid_mao_zedong_thought      | none   | 5      | acc    | 0.9167 | ± 0.0576 |
+| - ceval-valid_marxism                 | none   | 5      | acc    | 0.9474 | ± 0.0526 |
+| - ceval-valid_metrology_engineer      | none   | 5      | acc    | 0.8750 | ± 0.0690 |
+| - ceval-valid_middle_school_biology   | none   | 5      | acc    | 0.8571 | ± 0.0782 |
+| - ceval-valid_middle_school_chemistry | none   | 5      | acc    | 1.0000 | ± 0.0000 |
+| - ceval-valid_middle_school_geography | none   | 5      | acc    | 0.8333 | ± 0.1124 |
+| - ceval-valid_middle_school_history   | none   | 5      | acc    | 0.9545 | ± 0.0455 |
+| - ceval-valid_middle_school_mathematics | none   | 5      | acc    | 0.8947 | ± 0.0723 |
+| - ceval-valid_middle_school_physics   | none   | 5      | acc    | 0.9474 | ± 0.0526 |
+| - ceval-valid_middle_school_politics  | none   | 5      | acc    | 0.9524 | ± 0.0476 |
+| - ceval-valid_modern_chinese_history  | none   | 5      | acc    | 0.8696 | ± 0.0718 |
+| - ceval-valid_operating_system        | none   | 5      | acc    | 0.8947 | ± 0.0723 |
+| - ceval-valid_physician               | none   | 5      | acc    | 0.8163 | ± 0.0559 |
+| - ceval-valid_plant_protection        | none   | 5      | acc    | 0.8182 | ± 0.0842 |
+| - ceval-valid_probability_and_statistics | none   | 5      | acc    | 0.6111 | ± 0.1182 |
+| - ceval-valid_professional_tour_guide | none   | 5      | acc    | 0.8621 | ± 0.0652 |
+| - ceval-valid_sports_science          | none   | 5      | acc    | 1.0000 | ± 0.0000 |
+| - ceval-valid_tax_accountant          | none   | 5      | acc    | 0.7551 | ± 0.0621 |
+| - ceval-valid_teacher_qualification   | none   | 5      | acc    | 0.9545 | ± 0.0318 |
+| - ceval-valid_urban_and_rural_planner | none   | 5      | acc    | 0.7609 | ± 0.0636 |
+| - ceval-valid_veterinary_medicine     | none   | 5      | acc    | 0.9130 | ± 0.0601 |
+</details>
+<details>
+<summary>gsm8k details</summary>
+
+| Task                  | Filter | n-shot | Metric   | Value   | Stderr |
+|-----------------------|-------:|-------:|----------|--------:|-------:|
+| gsm8k                                 | flexible-extract | 5      | exact_match | ✅0.8400 | ± 0.0101 |
+</details>

--- a/accuracy/accuracy_report/index.md
+++ b/accuracy/accuracy_report/index.md
@@ -1,6 +1,9 @@
 # Accuracy Report
 
-:::{toctree}
+::: {toctree}
 :caption: Accuracy Report
 :maxdepth: 1
+Qwen2.5-VL-7B-Instruct-V1
+Qwen3-30B-A3B-V1
+Qwen3-8B-Base-V1
 :::


### PR DESCRIPTION
The accuracy results running on NPU Altlas A2 have changed, updating reports for:
All models (Qwen/Qwen3-30B-A3B, Qwen2.5-VL-7B-Instruct, Qwen3-8B-Base)

- [Workflow run][1]

[1]: https://github.com/nv-action/vllm-benchmarks/actions/runs/16187427474