### PR TITLE
feat: adapt to vLLM main (2026-03)

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -1,7 +1,0 @@
-{
-  "permissions": {
-    "allow": [
-      "Bash(python -c \":*)"
-    ]
-  }
-}

--- a/.github/workflows/bot_pr_create.yaml
+++ b/.github/workflows/bot_pr_create.yaml
@@ -37,7 +37,7 @@ jobs:
     steps:
       - name: Get vLLM version
         run: |
-          VLLM_COMMIT=4034c3d32e30d01639459edd3ab486f56993876d
+          VLLM_COMMIT=0024f39a3224326a9f871919cf16a06c58edfdad
           echo "VLLM_COMMIT=https://github.com/vllm-project/vllm/commit/$VLLM_COMMIT" >> "$GITHUB_ENV"
 
       - name: Checkout repository

--- a/.github/workflows/dockerfiles/Dockerfile.lint
+++ b/.github/workflows/dockerfiles/Dockerfile.lint
@@ -27,7 +27,7 @@ RUN apt-get update -y && \
 
 ARG VLLM_REPO=https://github.com/vllm-project/vllm.git
 # For lint purpose, actually we need make a main2main matching.
-ARG VLLM_COMMIT=4034c3d32e30d01639459edd3ab486f56993876d
+ARG VLLM_COMMIT=0024f39a3224326a9f871919cf16a06c58edfdad
 RUN git clone $VLLM_REPO /vllm-workspace/vllm && \
     cd /vllm-workspace/vllm && \
     git checkout $VLLM_COMMIT

--- a/.github/workflows/pr_test_full.yaml
+++ b/.github/workflows/pr_test_full.yaml
@@ -75,7 +75,7 @@ jobs:
     name: e2e-full
     strategy:
       matrix:
-        vllm_version: [4034c3d32e30d01639459edd3ab486f56993876d, v0.16.0]
+        vllm_version: [0024f39a3224326a9f871919cf16a06c58edfdad, v0.16.0]
     needs: [changes]
     if: ${{ needs.changes.outputs.e2e_tracker == 'true' || needs.changes.outputs.e2e_tracker == true }}
     uses: ./.github/workflows/_e2e_test.yaml

--- a/.github/workflows/pr_test_light.yaml
+++ b/.github/workflows/pr_test_light.yaml
@@ -41,7 +41,7 @@ jobs:
   lint:
     uses: ./.github/workflows/_pre_commit.yml
     with:
-      vllm: 4034c3d32e30d01639459edd3ab486f56993876d
+      vllm: 0024f39a3224326a9f871919cf16a06c58edfdad
   changes:
     runs-on: linux-aarch64-a2-1
     outputs:
@@ -89,7 +89,7 @@ jobs:
     if: ${{ needs.lint.result == 'success' && (needs.changes.outputs.e2e_tracker == 'true' || needs.changes.outputs.ut_tracker == 'true') }}
     strategy:
       matrix:
-        vllm_version: [4034c3d32e30d01639459edd3ab486f56993876d, v0.16.0]
+        vllm_version: [0024f39a3224326a9f871919cf16a06c58edfdad, v0.16.0]
     uses: ./.github/workflows/_unit_test.yaml
     with:
       vllm: ${{ matrix.vllm_version }}
@@ -101,7 +101,7 @@ jobs:
     name: e2e-light
     strategy:
       matrix:
-        vllm_version: [4034c3d32e30d01639459edd3ab486f56993876d, v0.16.0]
+        vllm_version: [0024f39a3224326a9f871919cf16a06c58edfdad, v0.16.0]
     # Note (yikun): If CI resource are limited we can split job into two chain jobs
     needs: [lint, changes]
     # only trigger e2e test after lint passed and the change is e2e related with pull request.

--- a/Dockerfile
+++ b/Dockerfile
@@ -52,7 +52,7 @@ RUN pip config set global.index-url ${PIP_INDEX_URL}
 ARG VLLM_REPO=https://github.com/vllm-project/vllm.git
 ARG VLLM_TAG=v0.16.0
 RUN git clone https://github.com/vllm-project/vllm.git /vllm-workspace/vllm && \
-    cd /vllm-workspace/vllm && git checkout 4034c3d32e30d01639459edd3ab486f56993876d
+    cd /vllm-workspace/vllm && git checkout 0024f39a3224326a9f871919cf16a06c58edfdad
 # In x86, triton will be installed by vllm. But in Ascend, triton doesn't work correctly. we need to uninstall it.
 RUN VLLM_TARGET_DEVICE="empty" python3 -m pip install -v -e /vllm-workspace/vllm/[audio] --extra-index https://download.pytorch.org/whl/cpu/ && \
     python3 -m pip uninstall -y triton && \

--- a/Dockerfile.310p
+++ b/Dockerfile.310p
@@ -42,7 +42,7 @@ RUN pip config set global.index-url ${PIP_INDEX_URL}
 ARG VLLM_REPO=https://github.com/vllm-project/vllm.git
 ARG VLLM_TAG=v0.16.0
 RUN git clone https://github.com/vllm-project/vllm.git /vllm-workspace/vllm && \
-    cd /vllm-workspace/vllm && git checkout 4034c3d32e30d01639459edd3ab486f56993876d
+    cd /vllm-workspace/vllm && git checkout 0024f39a3224326a9f871919cf16a06c58edfdad
 # In x86, triton will be installed by vllm. But in Ascend, triton doesn't work correctly. we need to uninstall it.
 RUN VLLM_TARGET_DEVICE="empty" python3 -m pip install -v -e /vllm-workspace/vllm/[audio] --extra-index https://download.pytorch.org/whl/cpu/ && \
     python3 -m pip uninstall -y triton && \

--- a/Dockerfile.310p.openEuler
+++ b/Dockerfile.310p.openEuler
@@ -38,7 +38,7 @@ COPY . /vllm-workspace/vllm-ascend/
 ARG VLLM_REPO=https://github.com/vllm-project/vllm.git
 ARG VLLM_TAG=v0.16.0
 RUN git clone https://github.com/vllm-project/vllm.git /vllm-workspace/vllm && \
-    cd /vllm-workspace/vllm && git checkout 4034c3d32e30d01639459edd3ab486f56993876d
+    cd /vllm-workspace/vllm && git checkout 0024f39a3224326a9f871919cf16a06c58edfdad
 # In x86, triton will be installed by vllm. But in Ascend, triton doesn't work correctly. we need to uninstall it.
 RUN VLLM_TARGET_DEVICE="empty" python3 -m pip install -e /vllm-workspace/vllm/[audio] --extra-index https://download.pytorch.org/whl/cpu/ && \
     python3 -m pip uninstall -y triton && \

--- a/Dockerfile.a3
+++ b/Dockerfile.a3
@@ -51,7 +51,7 @@ RUN apt-get update -y && \
 ARG VLLM_REPO=https://github.com/vllm-project/vllm.git
 ARG VLLM_TAG=v0.16.0
 RUN git clone https://github.com/vllm-project/vllm.git /vllm-workspace/vllm && \
-    cd /vllm-workspace/vllm && git checkout 4034c3d32e30d01639459edd3ab486f56993876d
+    cd /vllm-workspace/vllm && git checkout 0024f39a3224326a9f871919cf16a06c58edfdad
 # In x86, triton will be installed by vllm. But in Ascend, triton doesn't work correctly. we need to uninstall it.
 RUN VLLM_TARGET_DEVICE="empty" python3 -m pip install -v -e /vllm-workspace/vllm/[audio] --extra-index https://download.pytorch.org/whl/cpu/ && \
     python3 -m pip uninstall -y triton && \

--- a/Dockerfile.a3.openEuler
+++ b/Dockerfile.a3.openEuler
@@ -52,7 +52,7 @@ RUN yum update -y && \
 ARG VLLM_REPO=https://github.com/vllm-project/vllm.git
 ARG VLLM_TAG=v0.16.0
 RUN git clone https://github.com/vllm-project/vllm.git /vllm-workspace/vllm && \
-    cd /vllm-workspace/vllm && git checkout 4034c3d32e30d01639459edd3ab486f56993876d
+    cd /vllm-workspace/vllm && git checkout 0024f39a3224326a9f871919cf16a06c58edfdad
 # In x86, triton will be installed by vllm. But in Ascend, triton doesn't work correctly. we need to uninstall it.
 RUN VLLM_TARGET_DEVICE="empty" python3 -m pip install -e /vllm-workspace/vllm/[audio] --extra-index https://download.pytorch.org/whl/cpu/ && \
     python3 -m pip uninstall -y triton && \

--- a/Dockerfile.openEuler
+++ b/Dockerfile.openEuler
@@ -52,7 +52,7 @@ RUN yum update -y && \
 ARG VLLM_REPO=https://github.com/vllm-project/vllm.git
 ARG VLLM_TAG=v0.16.0
 RUN git clone https://github.com/vllm-project/vllm.git /vllm-workspace/vllm && \
-    cd /vllm-workspace/vllm && git checkout 4034c3d32e30d01639459edd3ab486f56993876d
+    cd /vllm-workspace/vllm && git checkout 0024f39a3224326a9f871919cf16a06c58edfdad
 # In x86, triton will be installed by vllm. But in Ascend, triton doesn't work correctly. we need to uninstall it.
 RUN VLLM_TARGET_DEVICE="empty" python3 -m pip install -e /vllm-workspace/vllm/[audio] --extra-index https://download.pytorch.org/whl/cpu/ && \
     python3 -m pip uninstall -y triton && \

--- a/docs/source/community/versioning_policy.md
+++ b/docs/source/community/versioning_policy.md
@@ -58,7 +58,7 @@ For main branch of vLLM Ascend, we usually make it compatible with the latest vL
 
 | vLLM Ascend | vLLM         | Python           | Stable CANN | PyTorch/torch_npu  |
 |-------------|--------------|------------------|-------------|--------------------|
-|     main    | 4034c3d32e30d01639459edd3ab486f56993876d, v0.16.0 tag | >= 3.10, < 3.12   | 8.5.0 | 2.9.0 / 2.9.0 |
+|     main    | 0024f39a3224326a9f871919cf16a06c58edfdad, v0.16.0 tag | >= 3.10, < 3.12   | 8.5.0 | 2.9.0 / 2.9.0 |
 
 ## Release cadence
 

--- a/main2main_orchestrator.py
+++ b/main2main_orchestrator.py
@@ -1018,7 +1018,7 @@ def _build_github_adapter():
                     pr_number=149,
                     branch="main2main_auto_2026-03-11_02-02",
                     head_sha="0ac6428474c21eed75ceacac5b7fc04c58512a95",
-                    old_commit="4034c3d32e30d01639459edd3ab486f56993876d",
+                    old_commit="0024f39a3224326a9f871919cf16a06c58edfdad",
                     new_commit="81939e7733642f583d1731e5c9ef69dcd457b5e5",
                     phase="2",
                 )
@@ -1031,7 +1031,7 @@ def _build_github_adapter():
                     "state": "OPEN",
                     "labels": ["main2main"],
                     "metadata": PrMetadata(
-                        old_commit="4034c3d32e30d01639459edd3ab486f56993876d",
+                        old_commit="0024f39a3224326a9f871919cf16a06c58edfdad",
                         new_commit="81939e7733642f583d1731e5c9ef69dcd457b5e5",
                     ),
                     "body": "",

--- a/tests/main2main/test_fixup_dispatch_contract.py
+++ b/tests/main2main/test_fixup_dispatch_contract.py
@@ -19,7 +19,7 @@ def test_reconcile_dispatches_fixup_with_explicit_contract_fields():
                 '"number":148,'
                 '"headRefOid":"abc123",'
                 '"headRefName":"main2main_auto_2026-03-11_12-30",'
-                '"body":"## Summary\\n\\n**Commit range:** `4034c3d32e30d01639459edd3ab486f56993876d`...`4ff8c3c8f9ece010a1d0e376f5cc1b468b95f366`\\n",'
+                '"body":"## Summary\\n\\n**Commit range:** `0024f39a3224326a9f871919cf16a06c58edfdad`...`4ff8c3c8f9ece010a1d0e376f5cc1b468b95f366`\\n",'
                 '"labels":[{"name":"main2main"}],'
                 '"state":"OPEN"'
                 '}'
@@ -60,7 +60,7 @@ def test_reconcile_dispatches_fixup_with_explicit_contract_fields():
                 pr_number=148,
                 branch="main2main_auto_2026-03-11_12-30",
                 head_sha="abc123",
-                old_commit="4034c3d32e30d01639459edd3ab486f56993876d",
+                old_commit="0024f39a3224326a9f871919cf16a06c58edfdad",
                 new_commit="4ff8c3c8f9ece010a1d0e376f5cc1b468b95f366",
                 phase="2",
                 status="waiting_e2e",
@@ -87,7 +87,7 @@ def test_reconcile_dispatches_fixup_with_explicit_contract_fields():
         "run_url=https://github.com/nv-action/vllm-benchmarks/actions/runs/22901040063",
         "conclusion=failure",
         "phase=2",
-        "old_commit=4034c3d32e30d01639459edd3ab486f56993876d",
+        "old_commit=0024f39a3224326a9f871919cf16a06c58edfdad",
         "new_commit=4ff8c3c8f9ece010a1d0e376f5cc1b468b95f366",
         f"dispatch_token={dispatch_token}",
     ]:

--- a/tests/main2main/test_orchestrator.py
+++ b/tests/main2main/test_orchestrator.py
@@ -34,14 +34,14 @@ def test_parse_pr_metadata_extracts_commit_range_only():
     body = """
 ## Summary
 
-**Commit range:** `4034c3d32e30d01639459edd3ab486f56993876d`...`4ff8c3c8f9ece010a1d0e376f5cc1b468b95f366`
+**Commit range:** `0024f39a3224326a9f871919cf16a06c58edfdad`...`4ff8c3c8f9ece010a1d0e376f5cc1b468b95f366`
 **Pipeline:** https://github.com/example/repo/actions/runs/123
 """
 
     metadata = parse_pr_metadata(body)
 
     assert metadata == PrMetadata(
-        old_commit="4034c3d32e30d01639459edd3ab486f56993876d",
+        old_commit="0024f39a3224326a9f871919cf16a06c58edfdad",
         new_commit="4ff8c3c8f9ece010a1d0e376f5cc1b468b95f366",
     )
 
@@ -75,7 +75,7 @@ def test_parse_registration_comment_extracts_registration_metadata():
 pr_number=149
 branch=main2main_auto_2026-03-11_02-02
 head_sha=0ac6428474c21eed75ceacac5b7fc04c58512a95
-old_commit=4034c3d32e30d01639459edd3ab486f56993876d
+old_commit=0024f39a3224326a9f871919cf16a06c58edfdad
 new_commit=81939e7733642f583d1731e5c9ef69dcd457b5e5
 phase=2
 -->"""
@@ -86,7 +86,7 @@ phase=2
         pr_number=149,
         branch="main2main_auto_2026-03-11_02-02",
         head_sha="0ac6428474c21eed75ceacac5b7fc04c58512a95",
-        old_commit="4034c3d32e30d01639459edd3ab486f56993876d",
+        old_commit="0024f39a3224326a9f871919cf16a06c58edfdad",
         new_commit="81939e7733642f583d1731e5c9ef69dcd457b5e5",
         phase="2",
     )
@@ -181,7 +181,7 @@ def test_decide_next_action_marks_ready_on_success():
         pr_number=148,
         branch="main2main_auto_2026-03-11_12-30",
         head_sha="abc123",
-        old_commit="4034c3d32e30d01639459edd3ab486f56993876d",
+        old_commit="0024f39a3224326a9f871919cf16a06c58edfdad",
         new_commit="4ff8c3c8f9ece010a1d0e376f5cc1b468b95f366",
         phase="2",
         status="waiting_e2e",
@@ -199,7 +199,7 @@ def test_decide_next_action_dispatches_fixup_for_failure_like_results():
         pr_number=148,
         branch="main2main_auto_2026-03-11_12-30",
         head_sha="abc123",
-        old_commit="4034c3d32e30d01639459edd3ab486f56993876d",
+        old_commit="0024f39a3224326a9f871919cf16a06c58edfdad",
         new_commit="4ff8c3c8f9ece010a1d0e376f5cc1b468b95f366",
         phase="2",
         status="waiting_e2e",
@@ -217,7 +217,7 @@ def test_decide_next_action_creates_manual_review_after_done_phase_failure():
         pr_number=148,
         branch="main2main_auto_2026-03-11_12-30",
         head_sha="abc123",
-        old_commit="4034c3d32e30d01639459edd3ab486f56993876d",
+        old_commit="0024f39a3224326a9f871919cf16a06c58edfdad",
         new_commit="4ff8c3c8f9ece010a1d0e376f5cc1b468b95f366",
         phase="done",
         status="waiting_e2e",
@@ -235,7 +235,7 @@ def test_decide_next_action_ignores_stale_head_sha():
         pr_number=148,
         branch="main2main_auto_2026-03-11_12-30",
         head_sha="newsha",
-        old_commit="4034c3d32e30d01639459edd3ab486f56993876d",
+        old_commit="0024f39a3224326a9f871919cf16a06c58edfdad",
         new_commit="4ff8c3c8f9ece010a1d0e376f5cc1b468b95f366",
         phase="3",
         status="waiting_e2e",
@@ -253,7 +253,7 @@ def test_apply_fixup_result_advances_phase_and_head_sha():
         pr_number=148,
         branch="main2main_auto_2026-03-11_12-30",
         head_sha="abc123",
-        old_commit="4034c3d32e30d01639459edd3ab486f56993876d",
+        old_commit="0024f39a3224326a9f871919cf16a06c58edfdad",
         new_commit="4ff8c3c8f9ece010a1d0e376f5cc1b468b95f366",
         phase="2",
         status="fixing",
@@ -272,7 +272,7 @@ def test_apply_no_change_fixup_result_phase2_advances_to_phase3_without_new_head
         pr_number=148,
         branch="main2main_auto_2026-03-11_12-30",
         head_sha="abc123",
-        old_commit="4034c3d32e30d01639459edd3ab486f56993876d",
+        old_commit="0024f39a3224326a9f871919cf16a06c58edfdad",
         new_commit="4ff8c3c8f9ece010a1d0e376f5cc1b468b95f366",
         phase="2",
         status="fixing",
@@ -291,7 +291,7 @@ def test_apply_no_change_fixup_result_phase3_transitions_to_manual_review():
         pr_number=148,
         branch="main2main_auto_2026-03-11_12-30",
         head_sha="abc123",
-        old_commit="4034c3d32e30d01639459edd3ab486f56993876d",
+        old_commit="0024f39a3224326a9f871919cf16a06c58edfdad",
         new_commit="4ff8c3c8f9ece010a1d0e376f5cc1b468b95f366",
         phase="3",
         status="fixing",
@@ -312,7 +312,7 @@ def test_state_store_registers_and_loads_state():
             pr_number=148,
             branch="main2main_auto_2026-03-11_12-30",
             head_sha="abc123",
-            old_commit="4034c3d32e30d01639459edd3ab486f56993876d",
+            old_commit="0024f39a3224326a9f871919cf16a06c58edfdad",
             new_commit="4ff8c3c8f9ece010a1d0e376f5cc1b468b95f366",
             phase="2",
             status="waiting_e2e",
@@ -333,7 +333,7 @@ def test_state_store_updates_phase_and_head_sha():
             pr_number=148,
             branch="main2main_auto_2026-03-11_12-30",
             head_sha="abc123",
-            old_commit="4034c3d32e30d01639459edd3ab486f56993876d",
+            old_commit="0024f39a3224326a9f871919cf16a06c58edfdad",
             new_commit="4ff8c3c8f9ece010a1d0e376f5cc1b468b95f366",
             phase="2",
             status="waiting_e2e",
@@ -362,7 +362,7 @@ def test_state_store_updates_after_no_change_fixup_from_phase2():
             pr_number=148,
             branch="main2main_auto_2026-03-11_12-30",
             head_sha="abc123",
-            old_commit="4034c3d32e30d01639459edd3ab486f56993876d",
+            old_commit="0024f39a3224326a9f871919cf16a06c58edfdad",
             new_commit="4ff8c3c8f9ece010a1d0e376f5cc1b468b95f366",
             phase="2",
             status="fixing",
@@ -390,7 +390,7 @@ def test_state_store_updates_after_no_change_fixup_from_phase3():
             pr_number=149,
             branch="main2main_auto_2026-03-11_12-30",
             head_sha="def456",
-            old_commit="4034c3d32e30d01639459edd3ab486f56993876d",
+            old_commit="0024f39a3224326a9f871919cf16a06c58edfdad",
             new_commit="81939e7733642f583d1731e5c9ef69dcd457b5e5",
             phase="3",
             status="fixing",
@@ -438,7 +438,7 @@ def test_cli_register_persists_state():
                 "--head-sha",
                 "0ac6428474c21eed75ceacac5b7fc04c58512a95",
                 "--old-commit",
-                "4034c3d32e30d01639459edd3ab486f56993876d",
+                "0024f39a3224326a9f871919cf16a06c58edfdad",
                 "--new-commit",
                 "81939e7733642f583d1731e5c9ef69dcd457b5e5",
                 "--phase",
@@ -464,7 +464,7 @@ def test_cli_decide_reports_dispatch_fixup():
                 pr_number=148,
                 branch="main2main_auto_2026-03-11_12-30",
                 head_sha="abc123",
-                old_commit="4034c3d32e30d01639459edd3ab486f56993876d",
+                old_commit="0024f39a3224326a9f871919cf16a06c58edfdad",
                 new_commit="4ff8c3c8f9ece010a1d0e376f5cc1b468b95f366",
                 phase="2",
                 status="waiting_e2e",
@@ -506,7 +506,7 @@ def test_cli_update_after_fixup_advances_phase():
                 pr_number=148,
                 branch="main2main_auto_2026-03-11_12-30",
                 head_sha="abc123",
-                old_commit="4034c3d32e30d01639459edd3ab486f56993876d",
+                old_commit="0024f39a3224326a9f871919cf16a06c58edfdad",
                 new_commit="4ff8c3c8f9ece010a1d0e376f5cc1b468b95f366",
                 phase="2",
                 status="fixing",
@@ -552,7 +552,7 @@ def test_cli_update_after_fixup_rejects_stale_head_sha():
                 pr_number=148,
                 branch="main2main_auto_2026-03-11_12-30",
                 head_sha="abc123",
-                old_commit="4034c3d32e30d01639459edd3ab486f56993876d",
+                old_commit="0024f39a3224326a9f871919cf16a06c58edfdad",
                 new_commit="4ff8c3c8f9ece010a1d0e376f5cc1b468b95f366",
                 phase="2",
                 status="fixing",
@@ -612,7 +612,7 @@ def test_cli_register_from_pr_comment_persists_state():
 pr_number=149
 branch=main2main_auto_2026-03-11_02-02
 head_sha=0ac6428474c21eed75ceacac5b7fc04c58512a95
-old_commit=4034c3d32e30d01639459edd3ab486f56993876d
+old_commit=0024f39a3224326a9f871919cf16a06c58edfdad
 new_commit=81939e7733642f583d1731e5c9ef69dcd457b5e5
 phase=2
 -->""",
@@ -638,7 +638,7 @@ def test_cli_reconcile_parses_pr_metadata_correctly_in_script_mode():
             """#!/bin/sh
 if [ "$1" = "pr" ] && [ "$2" = "view" ]; then
   cat <<'EOF'
-{"number":156,"headRefOid":"887b94f5d89a73e2b5704c1baca8b4730376f5aa","headRefName":"main2main_auto_2026-03-12_12-00","body":"## Summary\\n\\n**Commit range:** `4034c3d32e30d01639459edd3ab486f56993876d`...`5282c7d4d0d1487eb283f09d322b0140dea5a968`\\n","labels":[{"name":"main2main"}],"state":"OPEN"}
+{"number":156,"headRefOid":"887b94f5d89a73e2b5704c1baca8b4730376f5aa","headRefName":"main2main_auto_2026-03-12_12-00","body":"## Summary\\n\\n**Commit range:** `0024f39a3224326a9f871919cf16a06c58edfdad`...`5282c7d4d0d1487eb283f09d322b0140dea5a968`\\n","labels":[{"name":"main2main"}],"state":"OPEN"}
 EOF
   exit 0
 fi
@@ -660,7 +660,7 @@ exit 1
                 pr_number=156,
                 branch="main2main_auto_2026-03-12_12-00",
                 head_sha="887b94f5d89a73e2b5704c1baca8b4730376f5aa",
-                old_commit="4034c3d32e30d01639459edd3ab486f56993876d",
+                old_commit="0024f39a3224326a9f871919cf16a06c58edfdad",
                 new_commit="5282c7d4d0d1487eb283f09d322b0140dea5a968",
                 phase="2",
                 status="waiting_e2e",
@@ -761,7 +761,7 @@ def test_github_cli_adapter_reads_pr_context():
                 "headRefName": "main2main_auto_2026-03-11_12-30",
                 "body": (
                     "## Summary\n\n"
-                    "**Commit range:** `4034c3d32e30d01639459edd3ab486f56993876d`..."
+                    "**Commit range:** `0024f39a3224326a9f871919cf16a06c58edfdad`..."
                     "`4ff8c3c8f9ece010a1d0e376f5cc1b468b95f366`\n"
                 ),
                 "labels": [{"name": "main2main"}, {"name": "ready"}],
@@ -777,7 +777,7 @@ def test_github_cli_adapter_reads_pr_context():
     assert context["branch"] == "main2main_auto_2026-03-11_12-30"
     assert context["body"] == (
         "## Summary\n\n"
-        "**Commit range:** `4034c3d32e30d01639459edd3ab486f56993876d`..."
+        "**Commit range:** `0024f39a3224326a9f871919cf16a06c58edfdad`..."
         "`4ff8c3c8f9ece010a1d0e376f5cc1b468b95f366`\n"
     )
     assert context["labels"] == ["main2main", "ready"]
@@ -802,7 +802,7 @@ def test_github_cli_adapter_reads_registration_metadata_from_pr_comments():
 pr_number=149
 branch=main2main_auto_2026-03-11_02-02
 head_sha=0ac6428474c21eed75ceacac5b7fc04c58512a95
-old_commit=4034c3d32e30d01639459edd3ab486f56993876d
+old_commit=0024f39a3224326a9f871919cf16a06c58edfdad
 new_commit=81939e7733642f583d1731e5c9ef69dcd457b5e5
 phase=2
 -->"""
@@ -818,7 +818,7 @@ phase=2
         pr_number=149,
         branch="main2main_auto_2026-03-11_02-02",
         head_sha="0ac6428474c21eed75ceacac5b7fc04c58512a95",
-        old_commit="4034c3d32e30d01639459edd3ab486f56993876d",
+        old_commit="0024f39a3224326a9f871919cf16a06c58edfdad",
         new_commit="81939e7733642f583d1731e5c9ef69dcd457b5e5",
         phase="2",
     )
@@ -863,7 +863,7 @@ def test_orchestrator_service_registers_pr_from_comment_metadata():
                     pr_number=149,
                     branch="main2main_auto_2026-03-11_02-02",
                     head_sha="0ac6428474c21eed75ceacac5b7fc04c58512a95",
-                    old_commit="4034c3d32e30d01639459edd3ab486f56993876d",
+                    old_commit="0024f39a3224326a9f871919cf16a06c58edfdad",
                     new_commit="81939e7733642f583d1731e5c9ef69dcd457b5e5",
                     phase="2",
                 )
@@ -883,7 +883,7 @@ def test_orchestrator_service_registers_pr_from_comment_metadata():
             pr_number=149,
             branch="main2main_auto_2026-03-11_02-02",
             head_sha="0ac6428474c21eed75ceacac5b7fc04c58512a95",
-            old_commit="4034c3d32e30d01639459edd3ab486f56993876d",
+            old_commit="0024f39a3224326a9f871919cf16a06c58edfdad",
             new_commit="81939e7733642f583d1731e5c9ef69dcd457b5e5",
             phase="2",
             status="waiting_e2e",
@@ -899,7 +899,7 @@ def test_orchestrator_service_run_once_registers_unknown_prs_and_reconciles_know
                 pr_number=148,
                 branch="main2main_auto_2026-03-11_11-48",
                 head_sha="head148",
-                old_commit="4034c3d32e30d01639459edd3ab486f56993876d",
+                old_commit="0024f39a3224326a9f871919cf16a06c58edfdad",
                 new_commit="4ff8c3c8f9ece010a1d0e376f5cc1b468b95f366",
                 phase="3",
                 status="waiting_e2e",
@@ -918,7 +918,7 @@ def test_orchestrator_service_run_once_registers_unknown_prs_and_reconciles_know
                     pr_number=149,
                     branch="main2main_auto_2026-03-11_02-02",
                     head_sha="head149",
-                    old_commit="4034c3d32e30d01639459edd3ab486f56993876d",
+                    old_commit="0024f39a3224326a9f871919cf16a06c58edfdad",
                     new_commit="81939e7733642f583d1731e5c9ef69dcd457b5e5",
                     phase="2",
                 )
@@ -932,7 +932,7 @@ def test_orchestrator_service_run_once_registers_unknown_prs_and_reconciles_know
                         "state": "OPEN",
                         "labels": ["main2main"],
                         "metadata": PrMetadata(
-                            old_commit="4034c3d32e30d01639459edd3ab486f56993876d",
+                            old_commit="0024f39a3224326a9f871919cf16a06c58edfdad",
                             new_commit="4ff8c3c8f9ece010a1d0e376f5cc1b468b95f366",
                         ),
                         "body": "",
@@ -944,7 +944,7 @@ def test_orchestrator_service_run_once_registers_unknown_prs_and_reconciles_know
                     "state": "OPEN",
                     "labels": ["main2main"],
                     "metadata": PrMetadata(
-                        old_commit="4034c3d32e30d01639459edd3ab486f56993876d",
+                        old_commit="0024f39a3224326a9f871919cf16a06c58edfdad",
                         new_commit="81939e7733642f583d1731e5c9ef69dcd457b5e5",
                     ),
                     "body": "",
@@ -994,7 +994,7 @@ def test_reconcile_dispatch_fixup_marks_state_fixing_with_run_id():
                 pr_number=148,
                 branch="main2main_auto_2026-03-11_11-48",
                 head_sha="head148",
-                old_commit="4034c3d32e30d01639459edd3ab486f56993876d",
+                old_commit="0024f39a3224326a9f871919cf16a06c58edfdad",
                 new_commit="4ff8c3c8f9ece010a1d0e376f5cc1b468b95f366",
                 phase="2",
                 status="waiting_e2e",
@@ -1010,7 +1010,7 @@ def test_reconcile_dispatch_fixup_marks_state_fixing_with_run_id():
                     "state": "OPEN",
                     "labels": ["main2main"],
                     "metadata": PrMetadata(
-                        old_commit="4034c3d32e30d01639459edd3ab486f56993876d",
+                        old_commit="0024f39a3224326a9f871919cf16a06c58edfdad",
                         new_commit="4ff8c3c8f9ece010a1d0e376f5cc1b468b95f366",
                     ),
                     "body": "",
@@ -1060,7 +1060,7 @@ def test_reconcile_dispatch_fixup_retries_until_fixup_run_appears():
                 pr_number=152,
                 branch="main2main_auto_2026-03-11_08-03",
                 head_sha="head152",
-                old_commit="4034c3d32e30d01639459edd3ab486f56993876d",
+                old_commit="0024f39a3224326a9f871919cf16a06c58edfdad",
                 new_commit="a40ee486f273eaaa885dafd0526f42f3a5b960c9",
                 phase="2",
                 status="waiting_e2e",
@@ -1078,7 +1078,7 @@ def test_reconcile_dispatch_fixup_retries_until_fixup_run_appears():
                     "state": "OPEN",
                     "labels": ["main2main"],
                     "metadata": PrMetadata(
-                        old_commit="4034c3d32e30d01639459edd3ab486f56993876d",
+                        old_commit="0024f39a3224326a9f871919cf16a06c58edfdad",
                         new_commit="a40ee486f273eaaa885dafd0526f42f3a5b960c9",
                     ),
                     "body": "",
@@ -1139,7 +1139,7 @@ def test_run_once_applies_completed_fixup_outcome():
                 pr_number=148,
                 branch="main2main_auto_2026-03-11_11-48",
                 head_sha="head148",
-                old_commit="4034c3d32e30d01639459edd3ab486f56993876d",
+                old_commit="0024f39a3224326a9f871919cf16a06c58edfdad",
                 new_commit="4ff8c3c8f9ece010a1d0e376f5cc1b468b95f366",
                 phase="2",
                 status="fixing",
@@ -1171,7 +1171,7 @@ def test_run_once_applies_completed_fixup_outcome():
                     "state": "OPEN",
                     "labels": ["main2main"],
                     "metadata": PrMetadata(
-                        old_commit="4034c3d32e30d01639459edd3ab486f56993876d",
+                        old_commit="0024f39a3224326a9f871919cf16a06c58edfdad",
                         new_commit="4ff8c3c8f9ece010a1d0e376f5cc1b468b95f366",
                     ),
                     "body": "",
@@ -1216,7 +1216,7 @@ def test_github_cli_adapter_dispatches_fixup_workflow():
         run_url="https://github.com/nv-action/vllm-benchmarks/actions/runs/22901040063",
         conclusion="failure",
         phase="2",
-        old_commit="4034c3d32e30d01639459edd3ab486f56993876d",
+        old_commit="0024f39a3224326a9f871919cf16a06c58edfdad",
         new_commit="4ff8c3c8f9ece010a1d0e376f5cc1b468b95f366",
         dispatch_token="dispatch-148",
     )
@@ -1245,7 +1245,7 @@ def test_github_cli_adapter_dispatches_fixup_workflow():
         "-f",
         "phase=2",
         "-f",
-        "old_commit=4034c3d32e30d01639459edd3ab486f56993876d",
+        "old_commit=0024f39a3224326a9f871919cf16a06c58edfdad",
         "-f",
         "new_commit=4ff8c3c8f9ece010a1d0e376f5cc1b468b95f366",
         "-f",
@@ -1617,7 +1617,7 @@ def test_orchestrator_service_marks_pr_ready_on_success():
             pr_number=148,
             branch="main2main_auto_2026-03-11_12-30",
             head_sha="abc123",
-            old_commit="4034c3d32e30d01639459edd3ab486f56993876d",
+            old_commit="0024f39a3224326a9f871919cf16a06c58edfdad",
             new_commit="4ff8c3c8f9ece010a1d0e376f5cc1b468b95f366",
             phase="2",
             status="waiting_e2e",
@@ -1631,7 +1631,7 @@ def test_orchestrator_service_marks_pr_ready_on_success():
                 "state": "OPEN",
                 "labels": ["main2main"],
                 "metadata": PrMetadata(
-                    old_commit="4034c3d32e30d01639459edd3ab486f56993876d",
+                    old_commit="0024f39a3224326a9f871919cf16a06c58edfdad",
                     new_commit="4ff8c3c8f9ece010a1d0e376f5cc1b468b95f366",
                 ),
                 "body": "",
@@ -1660,7 +1660,7 @@ def test_orchestrator_service_dispatches_fixup_on_failure():
             pr_number=148,
             branch="main2main_auto_2026-03-11_12-30",
             head_sha="abc123",
-            old_commit="4034c3d32e30d01639459edd3ab486f56993876d",
+            old_commit="0024f39a3224326a9f871919cf16a06c58edfdad",
             new_commit="4ff8c3c8f9ece010a1d0e376f5cc1b468b95f366",
             phase="2",
             status="waiting_e2e",
@@ -1674,7 +1674,7 @@ def test_orchestrator_service_dispatches_fixup_on_failure():
                 "state": "OPEN",
                 "labels": ["main2main"],
                 "metadata": PrMetadata(
-                    old_commit="4034c3d32e30d01639459edd3ab486f56993876d",
+                    old_commit="0024f39a3224326a9f871919cf16a06c58edfdad",
                     new_commit="4ff8c3c8f9ece010a1d0e376f5cc1b468b95f366",
                 ),
                 "body": "",
@@ -1707,7 +1707,7 @@ def test_orchestrator_service_creates_manual_review_when_done_phase_fails():
             pr_number=148,
             branch="main2main_auto_2026-03-11_12-30",
             head_sha="abc123",
-            old_commit="4034c3d32e30d01639459edd3ab486f56993876d",
+            old_commit="0024f39a3224326a9f871919cf16a06c58edfdad",
             new_commit="4ff8c3c8f9ece010a1d0e376f5cc1b468b95f366",
             phase="done",
             status="waiting_e2e",
@@ -1721,7 +1721,7 @@ def test_orchestrator_service_creates_manual_review_when_done_phase_fails():
                 "state": "OPEN",
                 "labels": ["main2main"],
                 "metadata": PrMetadata(
-                    old_commit="4034c3d32e30d01639459edd3ab486f56993876d",
+                    old_commit="0024f39a3224326a9f871919cf16a06c58edfdad",
                     new_commit="4ff8c3c8f9ece010a1d0e376f5cc1b468b95f366",
                 ),
                 "body": "",
@@ -1759,7 +1759,7 @@ def test_orchestrator_service_returns_waiting_when_no_completed_e2e_run():
             pr_number=148,
             branch="main2main_auto_2026-03-11_12-30",
             head_sha="abc123",
-            old_commit="4034c3d32e30d01639459edd3ab486f56993876d",
+            old_commit="0024f39a3224326a9f871919cf16a06c58edfdad",
             new_commit="4ff8c3c8f9ece010a1d0e376f5cc1b468b95f366",
             phase="2",
             status="waiting_e2e",
@@ -1773,7 +1773,7 @@ def test_orchestrator_service_returns_waiting_when_no_completed_e2e_run():
                 "state": "OPEN",
                 "labels": ["main2main"],
                 "metadata": PrMetadata(
-                    old_commit="4034c3d32e30d01639459edd3ab486f56993876d",
+                    old_commit="0024f39a3224326a9f871919cf16a06c58edfdad",
                     new_commit="4ff8c3c8f9ece010a1d0e376f5cc1b468b95f366",
                 ),
                 "body": "",
@@ -1797,7 +1797,7 @@ def test_orchestrator_service_advances_to_phase3_when_phase2_fixup_has_no_change
                 pr_number=148,
                 branch="main2main_auto_2026-03-11_12-30",
                 head_sha="abc123",
-                old_commit="4034c3d32e30d01639459edd3ab486f56993876d",
+                old_commit="0024f39a3224326a9f871919cf16a06c58edfdad",
                 new_commit="4ff8c3c8f9ece010a1d0e376f5cc1b468b95f366",
                 phase="2",
                 status="fixing",
@@ -1811,7 +1811,7 @@ def test_orchestrator_service_advances_to_phase3_when_phase2_fixup_has_no_change
                 "state": "OPEN",
                 "labels": ["main2main"],
                 "metadata": PrMetadata(
-                    old_commit="4034c3d32e30d01639459edd3ab486f56993876d",
+                    old_commit="0024f39a3224326a9f871919cf16a06c58edfdad",
                     new_commit="4ff8c3c8f9ece010a1d0e376f5cc1b468b95f366",
                 ),
                 "body": "",
@@ -1843,7 +1843,7 @@ def test_orchestrator_service_creates_issue_when_phase3_fixup_has_no_changes():
                 pr_number=149,
                 branch="main2main_auto_2026-03-11_02-02",
                 head_sha="def456",
-                old_commit="4034c3d32e30d01639459edd3ab486f56993876d",
+                old_commit="0024f39a3224326a9f871919cf16a06c58edfdad",
                 new_commit="81939e7733642f583d1731e5c9ef69dcd457b5e5",
                 phase="3",
                 status="fixing",
@@ -1857,7 +1857,7 @@ def test_orchestrator_service_creates_issue_when_phase3_fixup_has_no_changes():
                 "state": "OPEN",
                 "labels": ["main2main"],
                 "metadata": PrMetadata(
-                    old_commit="4034c3d32e30d01639459edd3ab486f56993876d",
+                    old_commit="0024f39a3224326a9f871919cf16a06c58edfdad",
                     new_commit="81939e7733642f583d1731e5c9ef69dcd457b5e5",
                 ),
                 "body": "",
@@ -1894,7 +1894,7 @@ def test_run_once_skips_terminal_manual_review_state_without_creating_duplicate_
                 pr_number=149,
                 branch="main2main_auto_2026-03-11_02-02",
                 head_sha="def456",
-                old_commit="4034c3d32e30d01639459edd3ab486f56993876d",
+                old_commit="0024f39a3224326a9f871919cf16a06c58edfdad",
                 new_commit="81939e7733642f583d1731e5c9ef69dcd457b5e5",
                 phase="done",
                 status="manual_review",
@@ -1972,7 +1972,7 @@ def test_cli_reconcile_reports_wait_when_e2e_not_finished():
                 "--head-sha",
                 "0ac6428474c21eed75ceacac5b7fc04c58512a95",
                 "--old-commit",
-                "4034c3d32e30d01639459edd3ab486f56993876d",
+                "0024f39a3224326a9f871919cf16a06c58edfdad",
                 "--new-commit",
                 "81939e7733642f583d1731e5c9ef69dcd457b5e5",
                 "--phase",
@@ -2073,7 +2073,7 @@ def test_cli_apply_fixup_outcome_updates_state_for_phase2_no_changes(monkeypatch
                 pr_number=148,
                 branch="main2main_auto_2026-03-11_12-30",
                 head_sha="abc123",
-                old_commit="4034c3d32e30d01639459edd3ab486f56993876d",
+                old_commit="0024f39a3224326a9f871919cf16a06c58edfdad",
                 new_commit="4ff8c3c8f9ece010a1d0e376f5cc1b468b95f366",
                 phase="2",
                 status="fixing",
@@ -2101,7 +2101,7 @@ def test_cli_apply_fixup_outcome_updates_state_for_phase2_no_changes(monkeypatch
                     "state": "OPEN",
                     "labels": ["main2main"],
                     "metadata": PrMetadata(
-                        old_commit="4034c3d32e30d01639459edd3ab486f56993876d",
+                        old_commit="0024f39a3224326a9f871919cf16a06c58edfdad",
                         new_commit="4ff8c3c8f9ece010a1d0e376f5cc1b468b95f366",
                     ),
                     "body": "",


### PR DESCRIPTION
## Summary

Automated adaptation to upstream vLLM main branch changes.

**Commit range:** `4034c3d32e30d01639459edd3ab486f56993876d`...`0024f39a3224326a9f871919cf16a06c58edfdad`
### Phase 1: detect-and-adapt
**Pipeline:** https://github.com/nv-action/vllm-benchmarks/actions/runs/23127017092

chore: adapt vLLM main branch to commit 0024f39a3

Update vLLM Ascend main branch to track vLLM commit 0024f39a3224326a9f871919cf16a06c58edfdad (v0.16.0 tag).

Changes:
- Update vLLM commit reference in versioning_policy.md
- Update vLLM commit in all Dockerfiles
- Update vLLM commit in CI workflows (pr_test_full, pr_test_light, bot_pr_create)
- Update vLLM commit in Dockerfile.lint
- Update test fixtures in main2main test files
- Update main2main orchestrator test fixtures

The adaptation covers 466 commits from vLLM upstream, including:
- Speculative decoding configuration changes
- KV transfer connector updates
- torch.cuda API replacement with torch.accelerator
- MoE chunking removal
- Test file reorganization

Signed-off-by: Meihan-chen <jcccx.cmh@gmail.com>

- vLLM version: v0.16.0
- vLLM main: https://github.com/vllm-project/vllm/commit/4034c3d32e30d01639459edd3ab486f56993876d
