### PR TITLE
feat(ci): add buildkit fuse-overlayfs test for 910b and 310p Dockerfiles

### DIFF
--- a/.github/workflows/buildkit-dockerfile-test-group1.yaml
+++ b/.github/workflows/buildkit-dockerfile-test-group1.yaml
@@ -46,6 +46,27 @@ jobs:
               ;;
           esac
 
+      - name: Login to Quay (temp account)
+        uses: docker/login-action@v4
+        with:
+          registry: quay.io
+          username: ${{ vars.QUAY_TEMP_USERNAME }}
+          password: ${{ secrets.QUAY_TEMP_PASSWORD }}
+
+      - name: Login to Quay (main account)
+        uses: docker/login-action@v4
+        with:
+          registry: quay.io
+          username: ${{ vars.QUAY_USERNAME }}
+          password: ${{ secrets.QUAY_PASSWORD }}
+
+      - name: Login to SWR
+        uses: docker/login-action@v4
+        with:
+          registry: swr.cn-southwest-2.myhuaweicloud.com
+          username: ${{ secrets.SWR_USERNAME }}
+          password: ${{ secrets.SWR_PASSWORD }}
+
       - name: Build and push
         uses: docker/build-push-action@v7
         with:

--- a/.github/workflows/buildkit-dockerfile-test-group1.yaml
+++ b/.github/workflows/buildkit-dockerfile-test-group1.yaml
@@ -1,0 +1,70 @@
+name: buildkit-dockerfile-test-group1
+
+on:
+  pull_request:
+    paths:
+      - '.github/workflows/buildkit-dockerfile-test-group1.yaml'
+      - 'Dockerfile'
+      - 'Dockerfile.310p'
+      - 'Dockerfile.310p.openEuler'
+  workflow_dispatch:
+
+jobs:
+  build-test:
+    name: "${{ matrix.dockerfile }} (${{ matrix.runner_info.arch }})"
+    runs-on: ${{ matrix.runner_info.runner }}
+    container:
+      image: swr.cn-southwest-2.myhuaweicloud.com/base_image/ascend-ci/cann:9.0.0-a3-ubuntu22.04-py3.12
+
+    strategy:
+      fail-fast: false
+      matrix:
+        dockerfile:
+          - Dockerfile
+          - Dockerfile.310p
+          - Dockerfile.310p.openEuler
+        runner_info:
+          - {runner: linux-aarch64-cpu-4-buildkit-gy006, arch: arm64}
+          - {runner: linux-amd64-cpu-4-buildkit-gy006, arch: amd64}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Determine SOC_VERSION
+        id: vars
+        run: |
+          case "${{ matrix.dockerfile }}" in
+            Dockerfile|Dockerfile.openEuler)
+              echo "soc_version=ascend910b1" >> $GITHUB_OUTPUT
+              ;;
+            Dockerfile.310p|Dockerfile.310p.openEuler)
+              echo "soc_version=ascend310p1" >> $GITHUB_OUTPUT
+              ;;
+          esac
+
+      - name: Build and push
+        uses: docker/build-push-action@v7
+        with:
+          context: .
+          file: ${{ matrix.dockerfile }}
+          push: true
+          tags: |
+            swr.cn-southwest-2.myhuaweicloud.com/modelfoundry/test-buildkit:${{ matrix.dockerfile }}-${{ matrix.runner_info.arch }}-${{ github.sha }}
+            swr.cn-southwest-2.myhuaweicloud.com/modelfoundry/buildkit-cache:${{ matrix.dockerfile }}-${{ matrix.runner_info.arch }}
+          build-args: |
+            APTMIRROR=http://cache-service.nginx-pypi-cache.svc.cluster.local:8081
+            PIP_INDEX_URL=http://cache-service.nginx-pypi-cache.svc.cluster.local/pypi/simple
+            PIP_TRUSTED_HOST=cache-service.nginx-pypi-cache.svc.cluster.local
+            PYTORCH_INDEX_URL=http://cache-service.nginx-pypi-cache.svc.cluster.local/whl/cpu
+            ASCEND_INDEX_URL=http://cache-service.nginx-pypi-cache.svc.cluster.local/ascend/repos/pypi
+            GIT_PROXY=https://gh-proxy.test.osinfra.cn/
+            VLLM_ASCEND_IMAGE=swr.cn-southwest-2.myhuaweicloud.com/base_image/ascend-ci/vllm-ascend/vllm-ascend-ci
+            SOC_VERSION=${{ steps.vars.outputs.soc_version }}
+            COMPILE_CUSTOM_KERNELS=0
+          cache-from: type=registry,ref=swr.cn-southwest-2.myhuaweicloud.com/modelfoundry/buildkit-cache:${{ matrix.dockerfile }}-${{ matrix.runner_info.arch }}
+          cache-to: type=inline
+          provenance: false

--- a/.github/workflows/buildkit-dockerfile-test-group1.yaml
+++ b/.github/workflows/buildkit-dockerfile-test-group1.yaml
@@ -24,8 +24,8 @@ jobs:
           - Dockerfile.310p
           - Dockerfile.310p.openEuler
         runner_info:
-          - {runner: linux-aarch64-cpu-4-buildkit-gy006, arch: arm64}
-          - {runner: linux-amd64-cpu-4-buildkit-gy006, arch: amd64}
+          - {runner: linux-aarch64-a2-5c8g-v-gy006, arch: arm64}
+          - {runner: linux-aarch64-a2-5c8g-v-gy006, arch: amd64}
 
     steps:
       - name: Checkout

--- a/.github/workflows/buildkit-dockerfile-test-group1.yaml
+++ b/.github/workflows/buildkit-dockerfile-test-group1.yaml
@@ -25,7 +25,7 @@ jobs:
           - Dockerfile.310p.openEuler
         runner_info:
           - {runner: linux-aarch64-a2-5c8g-v-gy006, arch: arm64}
-          - {runner: linux-aarch64-a2-5c8g-v-gy006, arch: amd64}
+          - {runner: linux-aarch64-a2-10c16g-v-gy006, arch: arm64}
 
     steps:
       - name: Checkout

--- a/.github/workflows/buildkit-dockerfile-test-group1.yaml
+++ b/.github/workflows/buildkit-dockerfile-test-group1.yaml
@@ -24,8 +24,8 @@ jobs:
           - Dockerfile.310p
           - Dockerfile.310p.openEuler
         runner_info:
-          - {runner: linux-aarch64-a2-5c8g-v-gy006, arch: arm64}
-          - {runner: linux-aarch64-a2-10c16g-v-gy006, arch: arm64}
+          - {runner: linux-aarch64-cpu-4-buildkit-gy006, arch: arm64}
+          - {runner: linux-amd64-cpu-4-buildkit-gy006, arch: amd64}
 
     steps:
       - name: Checkout

--- a/.github/workflows/buildkit-dockerfile-test-group1.yaml
+++ b/.github/workflows/buildkit-dockerfile-test-group1.yaml
@@ -12,7 +12,7 @@ on:
 jobs:
   build-test:
     name: "${{ matrix.dockerfile }} (${{ matrix.runner_info.arch }})"
-    runs-on: ${{ fromJSON(matrix.runner_info.runner) }}
+    runs-on: ${{ matrix.runner_info.runner }}
     container:
       image: swr.cn-southwest-2.myhuaweicloud.com/base_image/ascend-ci/cann:9.0.0-a3-ubuntu22.04-py3.12
 
@@ -24,8 +24,8 @@ jobs:
           - Dockerfile.310p
           - Dockerfile.310p.openEuler
         runner_info:
-          - {runner: '["linux-aarch64-a2-5c8g-v","gy-006"]', arch: arm64}
-          - {runner: '["linux-aarch64-a2-10c16g-v","gy-006"]', arch: arm64}
+          - {runner: linux-aarch64-a2-5c8g-v-gy006, arch: arm64}
+          - {runner: linux-aarch64-a2-10c16g-v-gy006, arch: arm64}
 
     steps:
       - name: Checkout

--- a/.github/workflows/buildkit-dockerfile-test-group1.yaml
+++ b/.github/workflows/buildkit-dockerfile-test-group1.yaml
@@ -12,7 +12,7 @@ on:
 jobs:
   build-test:
     name: "${{ matrix.dockerfile }} (${{ matrix.runner_info.arch }})"
-    runs-on: ${{ matrix.runner_info.runner }}
+    runs-on: ${{ fromJSON(matrix.runner_info.runner) }}
     container:
       image: swr.cn-southwest-2.myhuaweicloud.com/base_image/ascend-ci/cann:9.0.0-a3-ubuntu22.04-py3.12
 
@@ -24,8 +24,8 @@ jobs:
           - Dockerfile.310p
           - Dockerfile.310p.openEuler
         runner_info:
-          - {runner: linux-aarch64-a2-5c8g-v, arch: arm64}
-          - {runner: linux-aarch64-a2-10c16g-v, arch: arm64}
+          - {runner: '["linux-aarch64-a2-5c8g-v","gy-006"]', arch: arm64}
+          - {runner: '["linux-aarch64-a2-10c16g-v","gy-006"]', arch: arm64}
 
     steps:
       - name: Checkout

--- a/.github/workflows/buildkit-dockerfile-test-group1.yaml
+++ b/.github/workflows/buildkit-dockerfile-test-group1.yaml
@@ -24,8 +24,8 @@ jobs:
           - Dockerfile.310p
           - Dockerfile.310p.openEuler
         runner_info:
-          - {runner: linux-aarch64-a2-5c8g-v-gy006, arch: arm64}
-          - {runner: linux-aarch64-a2-10c16g-v-gy006, arch: arm64}
+          - {runner: linux-aarch64-a2-5c8g-v, arch: arm64}
+          - {runner: linux-aarch64-a2-10c16g-v, arch: arm64}
 
     steps:
       - name: Checkout

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,20 +15,29 @@
 # This file is a part of the vllm-ascend project.
 #
 
-FROM quay.io/ascend/cann:9.0.1-910b-ubuntu22.04-py3.12
+FROM swr.cn-southwest-2.myhuaweicloud.com/base_image/ascend-ci/cann:9.0.1-910b-ubuntu22.04-py3.12
 
-ARG PIP_INDEX_URL="https://mirrors.tuna.tsinghua.edu.cn/pypi/web/simple"
+ARG PIP_INDEX_URL="https://pypi.tuna.tsinghua.edu.cn/simple"
+ARG MOONCAKE_INDEX_URL="https://mirrors.aliyun.com/pypi/web/simple"
+ARG ASCEND_INDEX_URL="https://mirrors.huaweicloud.com/ascend/repos/pypi"
+ARG PYTORCH_INDEX_URL="https://download.pytorch.org/whl/cpu"
+ARG PIP_TRUSTED_HOST=""
+ARG GIT_PROXY=""
+ARG APTMIRROR
 
 WORKDIR /workspace
 
 # Install clang-15 (for triton-ascend) and Mooncake
 ARG MOONCAKE_TAG=0.3.11.post1
-RUN apt-get update -y && \
+RUN if [ -n "$APTMIRROR" ]; then \
+        sed -Ei "s@(ports|archive).ubuntu.com@${APTMIRROR#http://}@g" /etc/apt/sources.list; \
+    fi && \
+    apt-get update -y && \
     apt-get install -y git vim wget net-tools gcc g++ cmake numactl libnuma-dev libibverbs-dev libjemalloc2 libhiredis-dev clang-15 && \
     update-alternatives --install /usr/bin/clang clang /usr/bin/clang-15 20 && \
     update-alternatives --install /usr/bin/clang++ clang++ /usr/bin/clang++-15 20 && \
     source /usr/local/Ascend/ascend-toolkit/set_env.sh && \
-    python3 -m pip install mooncake-transfer-engine-npu==${MOONCAKE_TAG} --extra-index-url https://mirrors.aliyun.com/pypi/web/simple && \
+    python3 -m pip install mooncake-transfer-engine-npu==${MOONCAKE_TAG} --extra-index-url ${MOONCAKE_INDEX_URL} && \
     rm -rf /var/cache/apt/* && \
     rm -rf /var/lib/apt/lists/*
 
@@ -46,10 +55,11 @@ RUN if [ -n "$VLLM_COMMIT" ]; then \
       git -C /vllm-workspace/vllm fetch --depth 1 $VLLM_REPO "$VLLM_COMMIT" && \
       git -C /vllm-workspace/vllm checkout FETCH_HEAD; \
     else \
+      if [ -n "$GIT_PROXY" ]; then git config --global url."${GIT_PROXY}https://github.com/".insteadOf https://github.com/; fi && \
       git clone --depth 1 -b $VLLM_TAG $VLLM_REPO /vllm-workspace/vllm; \
     fi
 # In x86, triton will be installed by vllm. But in Ascend, triton doesn't work correctly. we need to uninstall it.
-RUN VLLM_TARGET_DEVICE="empty" python3 -m pip install -e /vllm-workspace/vllm/[audio] --extra-index https://download.pytorch.org/whl/cpu/ && \
+RUN VLLM_TARGET_DEVICE="empty" python3 -m pip install -e /vllm-workspace/vllm/[audio] && \
     python3 -m pip uninstall -y triton && \
     python3 -m pip cache purge
 
@@ -62,13 +72,13 @@ ENV SOC_VERSION=$SOC_VERSION \
     OMP_NUM_THREADS=1
 COPY . /vllm-workspace/vllm-ascend/
 
-RUN export PIP_EXTRA_INDEX_URL="https://mirrors.huaweicloud.com/ascend/repos/pypi" && \
+RUN export PIP_EXTRA_INDEX_URL="${ASCEND_INDEX_URL}" && \
     export VLLM_BATCH_INVARIANT=1 && \
     source /usr/local/Ascend/ascend-toolkit/set_env.sh && \
     source /usr/local/Ascend/nnal/atb/set_env.sh && \
-    python3 -m pip install -e /vllm-workspace/vllm-ascend/ --extra-index https://download.pytorch.org/whl/cpu/ && \
+    python3 -m pip install -e /vllm-workspace/vllm-ascend/ --find-links ${PYTORCH_INDEX_URL}/torch/ --find-links ${PYTORCH_INDEX_URL}/torchvision/ && \
     python3 -m pip uninstall -y triton triton-ascend && \
-    python3 -m pip install triton-ascend==3.2.1 --extra-index-url https://mirrors.huaweicloud.com/ascend/repos/pypi && \
+    python3 -m pip install triton-ascend==3.2.1 --extra-index-url ${ASCEND_INDEX_URL} && \
     python3 -m pip cache purge
 
 # Append `libascend_hal.so` path (devlib) to LD_LIBRARY_PATH

--- a/Dockerfile.310p
+++ b/Dockerfile.310p
@@ -15,13 +15,21 @@
 # This file is a part of the vllm-ascend project.
 #
 
-FROM quay.io/ascend/cann:9.1.0-beta.1-310p-ubuntu22.04-py3.12
+FROM swr.cn-southwest-2.myhuaweicloud.com/base_image/ascend-ci/cann:9.1.0-beta.1-310p-ubuntu22.04-py3.12
 
-ARG PIP_INDEX_URL="https://mirrors.tuna.tsinghua.edu.cn/pypi/web/simple"
+ARG PIP_INDEX_URL="https://pypi.tuna.tsinghua.edu.cn/simple"
+ARG ASCEND_INDEX_URL="https://mirrors.huaweicloud.com/ascend/repos/pypi"
+ARG PYTORCH_INDEX_URL="https://download.pytorch.org/whl/cpu"
+ARG PIP_TRUSTED_HOST=""
+ARG GIT_PROXY=""
+ARG APTMIRROR
 
 WORKDIR /workspace
 
-RUN apt-get update -y && \
+RUN if [ -n "$APTMIRROR" ]; then \
+        sed -Ei "s@(ports|archive).ubuntu.com@${APTMIRROR#http://}@g" /etc/apt/sources.list; \
+    fi && \
+    apt-get update -y && \
     apt-get install -y python3-pip git vim wget net-tools gcc g++ cmake numactl libnuma-dev libjemalloc2 pciutils && \
     rm -rf /var/cache/apt/* && \
     rm -rf /var/lib/apt/lists/*
@@ -40,10 +48,11 @@ RUN if [ -n "$VLLM_COMMIT" ]; then \
       git -C /vllm-workspace/vllm fetch --depth 1 $VLLM_REPO "$VLLM_COMMIT" && \
       git -C /vllm-workspace/vllm checkout FETCH_HEAD; \
     else \
+      if [ -n "$GIT_PROXY" ]; then git config --global url."${GIT_PROXY}https://github.com/".insteadOf https://github.com/; fi && \
       git clone --depth 1 -b $VLLM_TAG $VLLM_REPO /vllm-workspace/vllm; \
     fi
 # In x86, triton will be installed by vllm. But in Ascend, triton doesn't work correctly. we need to uninstall it.
-RUN VLLM_TARGET_DEVICE="empty" python3 -m pip install -e /vllm-workspace/vllm/[audio] --extra-index https://download.pytorch.org/whl/cpu/ && \
+RUN VLLM_TARGET_DEVICE="empty" python3 -m pip install -e /vllm-workspace/vllm/[audio] && \
     python3 -m pip uninstall -y triton && \
     python3 -m pip cache purge
 
@@ -56,10 +65,10 @@ ENV SOC_VERSION=$SOC_VERSION \
     OMP_NUM_THREADS=1
 COPY . /vllm-workspace/vllm-ascend/
 
-RUN export PIP_EXTRA_INDEX_URL="https://mirrors.huaweicloud.com/ascend/repos/pypi" && \
+RUN export PIP_EXTRA_INDEX_URL="${ASCEND_INDEX_URL}" && \
     source /usr/local/Ascend/ascend-toolkit/set_env.sh && \
     source /usr/local/Ascend/nnal/atb/set_env.sh && \
-    python3 -m pip install -e /vllm-workspace/vllm-ascend/ --extra-index https://download.pytorch.org/whl/cpu/ && \
+    python3 -m pip install -e /vllm-workspace/vllm-ascend/ --find-links ${PYTORCH_INDEX_URL}/torch/ --find-links ${PYTORCH_INDEX_URL}/torchvision/ && \
     python3 -m pip uninstall -y triton-ascend triton && \
     python3 -m pip cache purge
 

--- a/Dockerfile.310p.openEuler
+++ b/Dockerfile.310p.openEuler
@@ -15,9 +15,13 @@
 # This file is a part of the vllm-ascend project.
 #
 
-FROM quay.io/ascend/cann:9.1.0-beta.1-310p-openeuler24.03-py3.12
+FROM swr.cn-southwest-2.myhuaweicloud.com/base_image/ascend-ci/cann:9.1.0-beta.1-310p-openeuler24.03-py3.12
 
-ARG PIP_INDEX_URL="https://mirrors.tuna.tsinghua.edu.cn/pypi/web/simple"
+ARG PIP_INDEX_URL="https://pypi.tuna.tsinghua.edu.cn/simple"
+ARG ASCEND_INDEX_URL="https://mirrors.huaweicloud.com/ascend/repos/pypi"
+ARG PYTORCH_INDEX_URL="https://download.pytorch.org/whl/cpu"
+ARG PIP_TRUSTED_HOST=""
+ARG GIT_PROXY=""
 
 WORKDIR /workspace
 
@@ -39,10 +43,11 @@ RUN if [ -n "$VLLM_COMMIT" ]; then \
       git -C /vllm-workspace/vllm fetch --depth 1 $VLLM_REPO "$VLLM_COMMIT" && \
       git -C /vllm-workspace/vllm checkout FETCH_HEAD; \
     else \
+      if [ -n "$GIT_PROXY" ]; then git config --global url."${GIT_PROXY}https://github.com/".insteadOf https://github.com/; fi && \
       git clone --depth 1 -b $VLLM_TAG $VLLM_REPO /vllm-workspace/vllm; \
     fi
 # In x86, triton will be installed by vllm. But in Ascend, triton doesn't work correctly. we need to uninstall it.
-RUN VLLM_TARGET_DEVICE="empty" python3 -m pip install -e /vllm-workspace/vllm/[audio] --extra-index https://download.pytorch.org/whl/cpu/ && \
+RUN VLLM_TARGET_DEVICE="empty" python3 -m pip install -e /vllm-workspace/vllm/[audio] && \
     python3 -m pip uninstall -y triton && \
     python3 -m pip cache purge
 
@@ -54,10 +59,10 @@ ENV SOC_VERSION=$SOC_VERSION \
     OMP_NUM_THREADS=1
 COPY . /vllm-workspace/vllm-ascend/
 
-RUN export PIP_EXTRA_INDEX_URL="https://mirrors.huaweicloud.com/ascend/repos/pypi" && \
+RUN export PIP_EXTRA_INDEX_URL="${ASCEND_INDEX_URL}" && \
     source /usr/local/Ascend/ascend-toolkit/set_env.sh && \
     source /usr/local/Ascend/nnal/atb/set_env.sh && \
-    python3 -m pip install -e /vllm-workspace/vllm-ascend/ --extra-index https://download.pytorch.org/whl/cpu/ && \
+    python3 -m pip install -e /vllm-workspace/vllm-ascend/ --find-links ${PYTORCH_INDEX_URL}/torch/ --find-links ${PYTORCH_INDEX_URL}/torchvision/ && \
     python3 -m pip uninstall -y triton-ascend triton && \
     python3 -m pip cache purge
 


### PR DESCRIPTION
## Summary
- 新增 .github/workflows/buildkit-dockerfile-test-group1.yaml 用于 Dockerfile (910b)、Dockerfile.310p、Dockerfile.310p.openEuler 的 buildkit 构建测试
- 所有 Dockerfile 统一使用 nginx-pypi-cache 代理，不再硬编码外部镜像 URL
- ASCEND_INDEX_URL 指向集群内缓存
- vLLM 安装去掉了 PYTORCH_INDEX_URL 避免 jinja2 hash 冲突
- vllm-ascend 安装用 --find-links 替代 --extra-index-url，避免依赖污染