### PR TITLE
feat: add composite actions replacing docker/* with buildctl

### DIFF
--- a/.github/actions/README.md
+++ b/.github/actions/README.md
@@ -1,0 +1,88 @@
+# GitHub Actions buildctl Composite Actions
+
+替换 `docker/*` 官方 action，底层使用 `buildctl` 连接远程 buildkitd server。
+
+## 文件结构
+
+```
+.github/actions/
+├── build-push-action/         # 替换 docker/build-push-action@v7
+│   ├── action.yml
+│   └── buildctl-build.sh
+├── docker-login-action/       # 替换 docker/login-action@v4
+│   └── action.yml
+├── docker-setup-buildx-action/ # 替换 docker/setup-buildx-action@v4 (no-op)
+│   └── action.yml
+└── docker-setup-qemu-action/  # 替换 docker/setup-qemu-action@v4 (no-op)
+    └── action.yml
+```
+
+## 使用方式
+
+用户只需改 `uses` 一行，其他 `with` 参数完全不变：
+
+```yaml
+# 之前
+- uses: docker/login-action@v4
+- uses: docker/setup-buildx-action@v4
+- uses: docker/build-push-action@v7
+
+# 之后（用当前 repo）
+- uses: ./.github/actions/docker-login-action
+- uses: ./.github/actions/docker-setup-buildx-action
+- uses: ./.github/actions/build-push-action
+```
+
+## 完整对比（以 vllm-ascend 镜像构建为例）
+
+```yaml
+# ── 之前：docker/build-push-action@v7 ──
+- uses: docker/login-action@v4
+  with:
+    registry: quay.io
+    username: ${{ secrets.QUAY_USERNAME }}
+    password: ${{ secrets.QUAY_PASSWORD }}
+
+- uses: docker/setup-buildx-action@v4
+
+- uses: docker/build-push-action@v7
+  with:
+    context: .
+    file: Dockerfile
+    push: true
+    tags: quay.io/ascend/vllm-ascend:nightly
+    build-args: |
+      VLLM_COMMIT=abc123
+    cache-from: type=registry,ref=ghcr.io/org/repo:buildcache
+    cache-to: type=registry,ref=ghcr.io/org/repo:buildcache,mode=max
+
+# ── 之后：只需改 uses（with 全部不变）──
+- uses: ./.github/actions/docker-login-action
+  with:
+    registry: quay.io
+    username: ${{ secrets.QUAY_USERNAME }}
+    password: ${{ secrets.QUAY_PASSWORD }}
+
+- uses: ./.github/actions/docker-setup-buildx-action
+
+- uses: ./.github/actions/build-push-action
+  with:
+    context: .
+    file: Dockerfile
+    push: true
+    tags: quay.io/ascend/vllm-ascend:nightly
+    build-args: |
+      VLLM_COMMIT=abc123
+    cache-from: type=registry,ref=ghcr.io/org/repo:buildcache
+    cache-to: type=registry,ref=ghcr.io/org/repo:buildcache,mode=max
+```
+
+## 注意事项
+
+1. **platforms 不需要设置**——builkitd 只构建本机架构（amd64 / arm64）
+
+2. **cache-to 使用 inline**——内部始终用 `--export-cache type=inline`，`mode=max` 会提示但不生效
+
+3. **setup-buildx 和 setup-qemu** 是 no-op，保留以兼容原有 workflow 结构
+
+4. **Runner 需要**：`BUILDKITD_ADDR` 和 `${DOCKER_CONFIG}/ca.pem,cert.pem,key.pem`（由 Runner Pod 注入）

--- a/.github/actions/build-push-action/action.yml
+++ b/.github/actions/build-push-action/action.yml
@@ -1,0 +1,132 @@
+name: 'Docker Build and Push (buildctl)'
+description: |
+  替换 docker/build-push-action@v7，底层使用 buildctl 连接远程 buildkitd。
+  with 参数完全兼容，用户只需改 uses 一行。
+author: 'ascend-ci'
+
+inputs:
+  context:
+    description: 'Build context path'
+    required: false
+    default: '.'
+  file:
+    description: 'Path to Dockerfile'
+    required: false
+    default: 'Dockerfile'
+  push:
+    description: 'Push to registry'
+    required: false
+    default: 'false'
+  tags:
+    description: 'Image tags (multi-line or comma-separated)'
+    required: false
+    default: ''
+  labels:
+    description: 'Image labels (multi-line key=value)'
+    required: false
+    default: ''
+  build-args:
+    description: 'Build arguments (multi-line KEY=VALUE)'
+    required: false
+    default: ''
+  cache-from:
+    description: 'Cache import (e.g. type=registry,ref=...,mode=max)'
+    required: false
+    default: ''
+  cache-to:
+    description: 'Cache export (buildctl uses inline, mode=max will be noted)'
+    required: false
+    default: ''
+  secrets:
+    description: 'Secrets (multi-line KEY=VALUE or KEY=file:...)'
+    required: false
+    default: ''
+  outputs:
+    description: 'Custom output (e.g. type=oci,dest=...), overrides tags'
+    required: false
+    default: ''
+  no-cache:
+    description: 'Do not use cache'
+    required: false
+    default: 'false'
+  pull:
+    description: 'Always pull base image'
+    required: false
+    default: 'false'
+  target:
+    description: 'Build target stage'
+    required: false
+    default: ''
+  network:
+    description: 'Set network mode (e.g. host)'
+    required: false
+    default: ''
+  ssh:
+    description: 'SSH agent socket'
+    required: false
+    default: ''
+  provenance:
+    description: 'Generate provenance attestation'
+    required: false
+    default: 'false'
+  sbom:
+    description: 'Generate SBOM attestation'
+    required: false
+    default: 'false'
+
+# 以下 input 保留以兼容 docker/build-push-action@v7，
+# 但不生效——buildctl 通过矩阵分架构、Runner 注凭证
+  platforms:
+    description: 'Ignored (per-arch runners)'
+    required: false
+    default: ''
+  github-token:
+    description: 'Ignored (credentials from env vars)'
+    required: false
+    default: ''
+  allow:
+    description: 'Ignored'
+    required: false
+    default: ''
+  annotations:
+    description: 'Ignored'
+    required: false
+    default: ''
+  load:
+    description: 'Ignored (buildctl pushes to registry)'
+    required: false
+    default: 'false'
+  build-contexts:
+    description: 'Ignored'
+    required: false
+    default: ''
+  ulimit:
+    description: 'Ignored'
+    required: false
+    default: ''
+
+runs:
+  using: composite
+  steps:
+    - name: Build and push with buildctl
+      shell: bash
+      env:
+        INPUT_CONTEXT: ${{ inputs.context }}
+        INPUT_FILE: ${{ inputs.file }}
+        INPUT_PUSH: ${{ inputs.push }}
+        INPUT_TAGS: ${{ inputs.tags }}
+        INPUT_LABELS: ${{ inputs.labels }}
+        INPUT_BUILD_ARGS: ${{ inputs.build-args }}
+        INPUT_CACHE_FROM: ${{ inputs.cache-from }}
+        INPUT_CACHE_TO: ${{ inputs.cache-to }}
+        INPUT_SECRETS: ${{ inputs.secrets }}
+        INPUT_OUTPUTS: ${{ inputs.outputs }}
+        INPUT_NO_CACHE: ${{ inputs.no-cache }}
+        INPUT_PULL: ${{ inputs.pull }}
+        INPUT_TARGET: ${{ inputs.target }}
+        INPUT_NETWORK: ${{ inputs.network }}
+        INPUT_SSH: ${{ inputs.ssh }}
+        INPUT_PROVENANCE: ${{ inputs.provenance }}
+        INPUT_SBOM: ${{ inputs.sbom }}
+      run: |
+        ${GITHUB_ACTION_PATH}/buildctl-build.sh

--- a/.github/actions/build-push-action/buildctl-build.sh
+++ b/.github/actions/build-push-action/buildctl-build.sh
@@ -1,0 +1,212 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# ── buildctl-build.sh
+# Translates docker/build-push-action inputs into buildctl build command.
+# Called by composite action .github/actions/build-push-action/action.yml
+
+echo "::group::buildctl: parsing inputs"
+
+# ── required arguments ──
+CONTEXT="${INPUT_CONTEXT:-.}"
+FILE="${INPUT_FILE:-Dockerfile}"
+PUSH="${INPUT_PUSH:-false}"
+BUILD_ARGS="${INPUT_BUILD_ARGS:-}"
+TAGS="${INPUT_TAGS:-}"
+LABELS="${INPUT_LABELS:-}"
+CACHE_FROM="${INPUT_CACHE_FROM:-}"
+CACHE_TO="${INPUT_CACHE_TO:-}"
+SECRETS="${INPUT_SECRETS:-}"
+OUTPUTS="${INPUT_OUTPUTS:-}"
+NO_CACHE="${INPUT_NO_CACHE:-false}"
+PULL="${INPUT_PULL:-false}"
+TARGET="${INPUT_TARGET:-}"
+NETWORK="${INPUT_NETWORK:-}"
+SSH="${INPUT_SSH:-}"
+PROVENANCE="${INPUT_PROVENANCE:-false}"
+SBOM="${INPUT_SBOM:-false}"
+
+# ── environment ──
+BUILDKITD_ADDR="${BUILDKITD_ADDR:-}"
+DOCKER_CONFIG="${DOCKER_CONFIG:-/home/user/.docker}"
+
+if [ -z "${BUILDKITD_ADDR}" ]; then
+  echo "::error::BUILDKITD_ADDR not set. Run on a self-hosted buildkit runner."
+  exit 1
+fi
+
+# ── base buildctl command ──
+CMD=(buildctl)
+CMD+=("--addr=${BUILDKITD_ADDR}")
+
+# TLS certs (may not always exist)
+for cert in ca.pem cert.pem key.pem; do
+  if [ -f "${DOCKER_CONFIG}/${cert}" ]; then
+    case "${cert}" in
+      ca.pem)   CMD+=("--tlscacert=${DOCKER_CONFIG}/${cert}") ;;
+      cert.pem) CMD+=("--tlscert=${DOCKER_CONFIG}/${cert}") ;;
+      key.pem)  CMD+=("--tlskey=${DOCKER_CONFIG}/${cert}") ;;
+    esac
+  fi
+done
+
+CMD+=(build --progress=plain --frontend dockerfile.v0)
+
+# ── Dockerfile path ──
+FILE_DIR="$(dirname "${FILE}")"
+FILE_NAME="$(basename "${FILE}")"
+CMD+=("--local" "context=${CONTEXT}" "--local" "dockerfile=${FILE_DIR}")
+CMD+=("--opt" "filename=${FILE_NAME}")
+
+echo "  context=${CONTEXT}  file=${FILE}"
+
+# ── build-args ──
+if [ -n "${BUILD_ARGS}" ]; then
+  while IFS= read -r line || [ -n "${line}" ]; do
+    line="$(echo "${line}" | sed 's/^[[:space:]]*//;s/[[:space:]]*$//')"
+    [ -z "${line}" ] && continue
+    CMD+=("--opt" "build-arg:${line}")
+    echo "  build-arg: ${line}"
+  done <<< "${BUILD_ARGS}"
+fi
+
+# ── cache-from ──
+if [ -n "${CACHE_FROM}" ]; then
+  while IFS= read -r line || [ -n "${line}" ]; do
+    line="$(echo "${line}" | sed 's/^[[:space:]]*//;s/[[:space:]]*$//')"
+    [ -z "${line}" ] && continue
+    CMD+=("--import-cache" "${line}")
+    echo "  cache-from: ${line}"
+  done <<< "${CACHE_FROM}"
+fi
+
+# ── secrets ──
+if [ -f "${DOCKER_CONFIG}/config.json" ]; then
+  CMD+=("--secret" "id=dockerconfig,src=${DOCKER_CONFIG}/config.json")
+fi
+if [ -n "${SECRETS}" ]; then
+  while IFS= read -r line || [ -n "${line}" ]; do
+    line="$(echo "${line}" | sed 's/^[[:space:]]*//;s/[[:space:]]*$//')"
+    [ -z "${line}" ] && continue
+    IFS='=' read -r key val <<< "${line}"
+    key="$(echo "${key}" | xargs)"
+    # env:<key> reads from environment variable, which GitHub secrets set
+    CMD+=("--secret" "id=${key},env=${key}")
+    echo "  secret: ${key}"
+  done <<< "${SECRETS}"
+fi
+
+# ── no-cache ──
+if [ "${NO_CACHE}" = "true" ]; then
+  CMD+=("--no-cache")
+  echo "  no-cache: true"
+fi
+
+# ── pull ── (experimental: use --opt image-resolve-mode=prefer-remote ?)
+# Not directly supported by dockerfile.v0; skip for now
+
+# ── target ──
+if [ -n "${TARGET}" ]; then
+  CMD+=("--opt" "target=${TARGET}")
+  echo "  target: ${TARGET}"
+fi
+
+# ── network ──
+if [ -n "${NETWORK}" ]; then
+  CMD+=("--opt" "network:${NETWORK}")
+  echo "  network: ${NETWORK}"
+fi
+
+# ── ssh ──
+if [ -n "${SSH}" ]; then
+  CMD+=("--ssh" "${SSH}")
+  echo "  ssh: ${SSH}"
+fi
+
+# ── labels ──
+if [ -n "${LABELS}" ]; then
+  while IFS= read -r line || [ -n "${line}" ]; do
+    line="$(echo "${line}" | sed 's/^[[:space:]]*//;s/[[:space:]]*$//')"
+    [ -z "${line}" ] && continue
+    CMD+=("--opt" "label:${line}")
+  done <<< "${LABELS}"
+fi
+
+# ── provenance ──
+if [ "${PROVENANCE}" = "true" ]; then
+  CMD+=("--opt" "attest:type=provenance,mode=max")
+  echo "  provenance: true"
+fi
+
+# ── sbom ──
+if [ "${SBOM}" = "true" ]; then
+  CMD+=("--opt" "attest:type=sbom,generator=sbom")
+  echo "  sbom: true"
+fi
+
+# ── output (image) ──
+# Tags: parse multi-line, produce comma-separated name=tag1,name=tag2
+# Default cache tag: append :buildcache to the first tag's image part
+OUTPUT_IMAGES=""
+HAS_PUSH="${PUSH}"
+
+if [ -n "${OUTPUTS}" ]; then
+  # Custom outputs: pass through as-is (e.g. type=oci,dest=...)
+  CMD+=("--output" "${OUTPUTS}")
+  echo "  output: ${OUTPUTS}"
+else
+  if [ -n "${TAGS}" ]; then
+    SEP=""
+    while IFS= read -r tag || [ -n "${tag}" ]; do
+      tag="$(echo "${tag}" | sed 's/^[[:space:]]*//;s/[[:space:]]*$//')"
+      [ -z "${tag}" ] && continue
+      OUTPUT_IMAGES="${OUTPUT_IMAGES}${SEP}name=${tag}"
+      SEP=","
+    done <<< "${TAGS}"
+  fi
+
+  if [ -z "${OUTPUT_IMAGES}" ]; then
+    echo "::warning::build-push-action: no tags set, building locally only"
+  fi
+
+  if [ "${HAS_PUSH}" = "true" ] && [ -n "${OUTPUT_IMAGES}" ]; then
+    OUTPUT="${OUTPUT_IMAGES},push=true"
+  else
+    OUTPUT="${OUTPUT_IMAGES}"
+    OUTPUT="${OUTPUT%,}"  # remove trailing comma
+  fi
+
+  if [ -n "${OUTPUT}" ]; then
+    CMD+=("--output" "type=image,${OUTPUT}")
+    echo "  output: type=image,${OUTPUT}"
+  else
+    # Build-only mode (no push, no tags): output to local tar to verify
+    CMD+=("--output" "type=dummy")
+    echo "  output: type=dummy (build-only)"
+  fi
+fi
+
+# ── export-cache ──
+if [ -n "${CACHE_TO}" ]; then
+  # docker/build-push-action cache-to format: type=registry,ref=...,mode=max
+  # We use inline for single-stage Dockerfiles.
+  # Detect if user explicitly set mode=max; if so, warn but still use inline.
+  if echo "${CACHE_TO}" | grep -q 'mode=max'; then
+    echo "::notice::build-push-action: cache-to mode=max requested, but buildkitd uses inline cache (single-stage Dockerfile)."
+  fi
+fi
+# Always use inline cache — simplest, no separate push
+CMD+=("--export-cache" "type=inline")
+
+echo "::endgroup::"
+
+echo "::group::buildctl: command"
+printf "  %s\n" "${CMD[@]}"
+echo "::endgroup::"
+
+echo "::group::buildctl: starting build"
+"${CMD[@]}"
+EXIT_CODE=$?
+echo "::endgroup::"
+
+exit "${EXIT_CODE}"

--- a/.github/actions/docker-login-action/action.yml
+++ b/.github/actions/docker-login-action/action.yml
@@ -1,0 +1,39 @@
+name: 'Docker Login (buildctl)'
+description: 'Registry login — sets BUILDKIT_REGISTRY_CREDS_* env for buildctl'
+author: 'ascend-ci'
+
+inputs:
+  registry:
+    description: 'Registry hostname (e.g. quay.io, ghcr.io)'
+    required: false
+    default: ''
+  username:
+    description: 'Registry username'
+    required: false
+    default: ''
+  password:
+    description: 'Registry password'
+    required: false
+    default: ''
+
+runs:
+  using: composite
+  steps:
+    - name: Set registry credentials for buildctl
+      shell: bash
+      run: |
+        if [ -z "${{ inputs.registry }}" ]; then
+          echo "::notice::docker-login: registry not set, skipping (buildctl uses Runner-injected credentials by default)"
+          exit 0
+        fi
+
+        REGISTRY_ENV="BUILDKIT_REGISTRY_CREDS_$(echo '${{ inputs.registry }}' | tr '[:lower:].' '[:upper:]_')"
+        CREDENTIALS="${{ inputs.username }}:${{ inputs.password }}"
+
+        if [ "${CREDENTIALS}" = ":" ]; then
+          echo "::warning::docker-login: username/password empty for ${{ inputs.registry }}"
+          exit 0
+        fi
+
+        echo "${REGISTRY_ENV}=${CREDENTIALS}" >> "$GITHUB_ENV"
+        echo "::notice::docker-login: ${REGISTRY_ENV} set for ${{ inputs.registry }}"

--- a/.github/actions/docker-setup-buildx-action/action.yml
+++ b/.github/actions/docker-setup-buildx-action/action.yml
@@ -1,0 +1,25 @@
+name: 'Docker Setup Buildx (buildctl)'
+description: 'No-op replacement for docker/setup-buildx-action. buildctl connects to remote buildkitd, no local daemon needed.'
+author: 'ascend-ci'
+
+inputs:
+  driver:
+    description: 'Ignored (buildctl uses remote buildkitd)'
+    required: false
+    default: ''
+  install:
+    description: 'Ignored'
+    required: false
+    default: 'false'
+  use:
+    description: 'Ignored'
+    required: false
+    default: 'false'
+
+runs:
+  using: composite
+  steps:
+    - name: No-op — buildkitd already running
+      shell: bash
+      run: |
+        echo "::notice::docker-setup-buildx: buildctl connects to buildkitd at ${BUILDKITD_ADDR}, no setup needed"

--- a/.github/actions/docker-setup-qemu-action/action.yml
+++ b/.github/actions/docker-setup-qemu-action/action.yml
@@ -1,0 +1,19 @@
+name: 'Docker Setup QEMU (buildctl)'
+description: 'No-op replacement for docker/setup-qemu-action. Multi-arch via per-arch runners, no QEMU needed.'
+author: 'ascend-ci'
+
+inputs:
+  platforms:
+    description: 'Ignored (per-arch runners)'
+    required: false
+    default: ''
+
+runs:
+  using: composite
+  steps:
+    - name: No-op — per-arch runners
+      shell: bash
+      run: |
+        ARCH=$(uname -m)
+        echo "::notice::docker-setup-qemu: running on ${ARCH} runner, no QEMU emulation needed"
+        echo "arch=${ARCH}" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
## Summary

合入后，所有 workflow 可用 `uses: nv-action/vllm-benchmarks/.github/actions/build-push-action@main` 替代 `docker/build-push-action@v7`。

### Action 清单

| Action | 替换 |
|--------|------|
| `build-push-action` | `docker/build-push-action@v7` → `buildctl build` |
| `docker-login-action` | `docker/login-action@v4` → `BUILDKIT_REGISTRY_CREDS_*` |
| `docker-setup-buildx-action` | no-op（buildctl 直连远程 buildkitd） |
| `docker-setup-qemu-action` | no-op（每架构独立 Runner） |

### 用法

```yaml
- uses: nv-action/vllm-benchmarks/.github/actions/build-push-action@main
  with:
    context: .
    file: Dockerfile
    push: true
    tags: quay.io/org/image:nightly
    build-args: |
      ARG1=value1
    cache-from: type=registry,ref=...
    cache-to: type=registry,ref=...,mode=max
```
