### PR TITLE
fix: limit dockerfile build parallelism to prevent SWR login failures

### DIFF
--- a/.github/workflows/buildkit-dockerfile-test-group1.yaml
+++ b/.github/workflows/buildkit-dockerfile-test-group1.yaml
@@ -36,6 +36,7 @@ jobs:
 
     strategy:
       fail-fast: false
+      max-parallel: 6
       matrix:
         dockerfile:
           - Dockerfile


### PR DESCRIPTION
## 问题
Docker 构建时，16 个并发任务导致 SWR 登录失败率高，部分 job 成功，部分失败。

## 根本原因
- 8 个 Dockerfile × 2 个 runner = 16 个并发任务
- SWR 无法处理如此高的并发登录请求，导致部分连接被拒绝
- buildkitd 资源竞争导致某些构建被中断

## 解决方案
在 strategy 中添加 `max-parallel: 6`，将并发任务数从 16 降低到 6。

## 效果
- 减轻 SWR 登录压力，登录失败率应明显下降
- buildkitd 内存占用降低
- 总耗时增加但构建稳定性提升

## 相关配置
结合 ascend-ci-deployment 中 guiyang-006 buildkitd 的并发数和 GC 优化（#1338），整体构建稳定性应得到显著改善。